### PR TITLE
Implement modern music player with metadata extraction

### DIFF
--- a/.env
+++ b/.env
@@ -20,13 +20,17 @@ APP_SECRET=ca60f7f3e11237632008202f1dde5d1b
 ###< symfony/framework-bundle ###
 
 ###> doctrine/doctrine-bundle ###
-# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
-# IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
-#
-# DATABASE_URL="sqlite:///%kernel.project_dir%/var/data_%kernel.environment%.db"
-# DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8&charset=utf8mb4"
-# DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
-DATABASE_URL="mysql://root:@127.0.0.1:3306/myplayerok?serverVersion=8.0&charset=utf8mb4"
+# These defaults work together with the Docker services declared in compose.yaml.
+# Override them in .env.local when running against a different database instance.
+MYSQL_HOST=127.0.0.1
+MYSQL_PORT=3306
+MYSQL_DATABASE=myplayerok
+MYSQL_USER=symfony
+MYSQL_PASSWORD=symfony
+MYSQL_ROOT_PASSWORD=root
+DATABASE_URL="mysql://%env(resolve:MYSQL_USER)%:%env(resolve:MYSQL_PASSWORD)%@%env(resolve:MYSQL_HOST)%:%env(resolve:MYSQL_PORT)%/%env(resolve:MYSQL_DATABASE)%?serverVersion=8.0&charset=utf8mb4"
+###< doctrine/doctrine-bundle ###
+
 ###> symfony/messenger ###
 # Choose one of the transports below
 # MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 /.env.*.local
 /config/secrets/prod/prod.decrypt.private.php
 /public/bundles/
+/public/uploads/*
+!/public/uploads/.gitignore
 /var/
 /vendor/
 ###< symfony/framework-bundle ###

--- a/Readme.md
+++ b/Readme.md
@@ -1,22 +1,73 @@
+# MyPlayerok
 
+Современный аудио-плеер на Symfony с поддержкой загрузки треков, чтения метаданных (исполнители, альбомы, обложки) и адаптивным интерфейсом на Bootstrap 5.
 
-## 1 Запуск локально
+## Требования
 
-В корне проекта выполнить:
-```shell
-php -S localhost:8000 -t public/
+* PHP >= 8.1 с расширениями `ctype`, `iconv`, `fileinfo`
+* [Composer](https://getcomposer.org/)
+* [Symfony CLI](https://symfony.com/download)
+* Docker и Docker Compose v2 (для базы данных и вспомогательных сервисов)
+
+## Подготовка окружения
+
+1. Установите зависимости проекта:
+   ```bash
+   symfony composer install
+   ```
+
+2. При необходимости скорректируйте подключение к базе данных в `.env.local`:
+   ```bash
+   cp .env .env.local
+   # затем измените значения MYSQL_* под свою среду
+   ```
+
+3. Запустите инфраструктурные сервисы (MySQL 8 и Mailpit) через Symfony CLI:
+   ```bash
+   symfony run -d --watch=config,src,templates,public docker compose up database mailer
+   ```
+   *По умолчанию MySQL слушает порт `3306`. Если порт занят, задайте другой перед запуском:*
+   ```bash
+   MYSQL_PORT=3307 symfony run -d --watch=config,src,templates,public docker compose up database mailer
+   ```
+
+4. Дождитесь, пока база данных станет доступна (healthcheck в `docker compose` проверяет готовность). Затем инициализируйте схему:
+   ```bash
+   symfony console doctrine:database:create --if-not-exists
+   symfony console doctrine:migrations:migrate --no-interaction
+   ```
+
+## Запуск приложения
+
+1. Запустите встроенный веб-сервер Symfony:
+   ```bash
+   symfony server:start -d
+   ```
+
+2. Откройте приложение по адресу, который выведет команда (обычно `https://127.0.0.1:8000`).
+
+3. Для остановки сервисов выполните:
+   ```bash
+   symfony server:stop
+   symfony run docker compose down
+   ```
+
+## Работа с треками
+
+* Загружайте аудиофайлы формата MP3/M4A/FLAC через раздел «Треки». Сервис автоматически считает название, исполнителя, альбом, жанр, длительность и обложку из ID3-тегов. Если метаданные отсутствуют, будут подставлены понятные значения по умолчанию.
+* Все файлы и обложки сохраняются в `public/uploads`. Каталог создаётся автоматически, но убедитесь, что у веб-сервера есть права на запись.
+
+## Полезные команды
+
+```bash
+# Очистить кеш
+symfony console cache:clear
+
+# Проверить корректность конфигурации Doctrine
+symfony console doctrine:schema:validate
+
+# Запустить тесты
+symfony php bin/phpunit
 ```
-## 2 Запуск базы данных
 
-В любом месте WSL
-```shell
-docker run --rm \
-  --name mysql-myplayerok \
-  -e MYSQL_DATABASE=myplayerok \
-  -e MYSQL_USER=vokintos \
-  -e MYSQL_PASSWORD=111 \
-  -e MYSQL_ROOT_PASSWORD=rootpassword \
-  -v mysql-data:/var/lib/mysql \
-  -p 3307:3306 \
-  mysql:8
-
+Готово! После выполнения шагов из этого файла приложение полностью готово к работе.

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -1,17 +1,14 @@
-
 services:
-###> doctrine/doctrine-bundle ###
   database:
     ports:
-      - "5432"
-###< doctrine/doctrine-bundle ###
+      - "${MYSQL_PORT:-3306}:3306"
 
 ###> symfony/mailer ###
   mailer:
     image: axllent/mailpit
     ports:
-      - "1025"
-      - "8025"
+      - "1025:1025"
+      - "8025:8025"
     environment:
       MP_SMTP_AUTH_ACCEPT_ANY: 1
       MP_SMTP_AUTH_ALLOW_INSECURE: 1

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,20 +1,24 @@
-
 services:
-###> doctrine/doctrine-bundle ###
   database:
-    image: postgres:${POSTGRES_VERSION:-16}-alpine
+    image: mysql:8.0
+    restart: unless-stopped
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-app}
-      # You should definitely change the password in production
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-!ChangeMe!}
-      POSTGRES_USER: ${POSTGRES_USER:-app}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-myplayerok}
+      MYSQL_USER: ${MYSQL_USER:-symfony}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-symfony}
+    command:
+      - --default-authentication-plugin=mysql_native_password
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
     volumes:
-      - database_data:/var/lib/postgresql/data:rw
-      # You may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!
-      # - ./docker/db/data:/var/lib/postgresql/data:rw
-###< doctrine/doctrine-bundle ###
+      - database_data:/var/lib/mysql:rw
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u${MYSQL_USER:-symfony}", "-p${MYSQL_PASSWORD:-symfony}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
 volumes:
-###> doctrine/doctrine-bundle ###
   database_data:
-###< doctrine/doctrine-bundle ###

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -1,5 +1,7 @@
 twig:
     default_path: '%kernel.project_dir%/templates'
+    form_themes:
+        - 'bootstrap_5_layout.html.twig'
 
 when@test:
     twig:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,8 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    app.upload_dir.tracks: '%kernel.project_dir%/public/uploads/tracks'
+    app.upload_dir.covers: '%kernel.project_dir%/public/uploads/covers'
 
 services:
     # default configuration for services in *this* file
@@ -19,6 +21,12 @@ services:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
+
+    App\Service\TrackManager:
+        arguments:
+            $tracksDirectory: '%app.upload_dir.tracks%'
+            $coversDirectory: '%app.upload_dir.covers%'
+            $projectDirectory: '%kernel.project_dir%'
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/migrations/Version20250915134944.php
+++ b/migrations/Version20250915134944.php
@@ -19,17 +19,11 @@ final class Version20250915134944 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE TABLE playlist (id INT AUTO_INCREMENT NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE track (id INT AUTO_INCREMENT NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE messenger_messages (id BIGINT AUTO_INCREMENT NOT NULL, body LONGTEXT NOT NULL, headers LONGTEXT NOT NULL, queue_name VARCHAR(190) NOT NULL, created_at DATETIME NOT NULL, available_at DATETIME NOT NULL, delivered_at DATETIME DEFAULT NULL, INDEX IDX_75EA56E0FB7336F0 (queue_name), INDEX IDX_75EA56E0E3BD61CE (available_at), INDEX IDX_75EA56E016BA31DB (delivered_at), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE track (id INT AUTO_INCREMENT NOT NULL, title VARCHAR(255) DEFAULT NULL, artist VARCHAR(255) DEFAULT NULL, duration INT DEFAULT NULL, file_path VARCHAR(255) NOT NULL, album VARCHAR(255) DEFAULT NULL, genre VARCHAR(100) DEFAULT NULL, cover_image VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
-        $this->addSql('DROP TABLE playlist');
         $this->addSql('DROP TABLE track');
-        $this->addSql('DROP TABLE messenger_messages');
     }
 }

--- a/public/app.css
+++ b/public/app.css
@@ -1,0 +1,261 @@
+:root {
+    --player-gradient-start: #141e30;
+    --player-gradient-end: #243b55;
+    --player-surface: rgba(15, 23, 42, 0.7);
+    --player-surface-hover: rgba(30, 41, 59, 0.85);
+    --player-accent: #ff6b6b;
+    --player-accent-soft: rgba(255, 107, 107, 0.15);
+    --player-text-primary: #f8fafc;
+    --player-text-muted: rgba(226, 232, 240, 0.75);
+    --player-border: rgba(148, 163, 184, 0.2);
+}
+
+body {
+    background: linear-gradient(135deg, var(--player-gradient-start) 0%, var(--player-gradient-end) 100%);
+    min-height: 100vh;
+    color: var(--player-text-primary);
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+a {
+    color: inherit;
+}
+
+a:hover {
+    color: var(--player-accent);
+}
+
+.player-app {
+    position: relative;
+    color: var(--player-text-primary);
+}
+
+.glass-panel {
+    background: var(--player-surface);
+    border: 1px solid var(--player-border);
+    border-radius: 24px;
+    backdrop-filter: blur(18px);
+    box-shadow: 0 20px 60px rgba(15, 23, 42, 0.45);
+}
+
+.section-title {
+    letter-spacing: 0.12em;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    color: var(--player-text-muted);
+}
+
+.filters .list-group-item {
+    background-color: transparent;
+    border: 1px solid transparent;
+    border-radius: 16px;
+    color: var(--player-text-muted);
+    transition: all 0.2s ease-in-out;
+    padding: 0.65rem 1rem;
+}
+
+.filters .list-group-item + .list-group-item {
+    margin-top: 0.25rem;
+}
+
+.filters .list-group-item.active,
+.filters .list-group-item:hover {
+    color: var(--player-text-primary);
+    border-color: var(--player-border);
+    background: var(--player-surface-hover);
+}
+
+.filters .badge {
+    background: var(--player-accent-soft);
+    color: var(--player-text-primary);
+}
+
+.track-collection {
+    max-height: calc(100vh - 260px);
+    overflow-y: auto;
+    padding-right: 0.5rem;
+}
+
+.track-collection::-webkit-scrollbar {
+    width: 6px;
+}
+
+.track-collection::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.4);
+    border-radius: 999px;
+}
+
+.track-item {
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 18px;
+    padding: 0.85rem 1rem;
+    transition: all 0.2s ease;
+    width: 100%;
+    text-align: left;
+    color: inherit;
+}
+
+.track-item:hover,
+.track-item:focus {
+    background: var(--player-surface-hover);
+    border-color: var(--player-border);
+    outline: none;
+}
+
+.track-item.active {
+    background: var(--player-accent-soft);
+    border-color: rgba(255, 107, 107, 0.35);
+}
+
+.track-cover {
+    width: 56px;
+    height: 56px;
+    border-radius: 16px;
+    overflow: hidden;
+    flex-shrink: 0;
+    background: rgba(148, 163, 184, 0.15);
+    display: grid;
+    place-items: center;
+}
+
+.track-cover img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.track-title {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+
+.track-meta {
+    font-size: 0.875rem;
+    color: var(--player-text-muted);
+}
+
+.track-duration {
+    font-variant-numeric: tabular-nums;
+    color: var(--player-text-muted);
+}
+
+.player-bar {
+    background: rgba(15, 23, 42, 0.92);
+    border-top: 1px solid var(--player-border);
+    backdrop-filter: blur(16px);
+    position: sticky;
+    bottom: 0;
+    width: 100%;
+    z-index: 10;
+    padding: 1rem 0;
+}
+
+.player-cover-sm {
+    width: 64px;
+    height: 64px;
+    border-radius: 18px;
+    overflow: hidden;
+    background: rgba(148, 163, 184, 0.25);
+    display: grid;
+    place-items: center;
+}
+
+.player-cover-sm img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.btn-circle {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: rgba(148, 163, 184, 0.2);
+    color: var(--player-text-primary);
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.btn-circle:hover,
+.btn-circle:focus {
+    background: rgba(148, 163, 184, 0.35);
+    transform: translateY(-1px);
+}
+
+.btn-circle.primary {
+    background: var(--player-accent);
+    color: #fff;
+    width: 50px;
+    height: 50px;
+}
+
+.btn-circle.primary:hover {
+    background: #ff8585;
+}
+
+.btn-circle[aria-pressed="true"] {
+    background: var(--player-accent);
+    color: #fff;
+}
+
+.progress-area {
+    width: 100%;
+}
+
+.progress-area input[type="range"] {
+    accent-color: var(--player-accent);
+}
+
+.volume-control input[type="range"] {
+    accent-color: var(--player-accent);
+}
+
+.empty-state {
+    text-align: center;
+    padding: 4rem 1rem;
+    color: var(--player-text-muted);
+}
+
+.empty-state .icon {
+    font-size: 3.5rem;
+    color: var(--player-accent);
+    margin-bottom: 1rem;
+}
+
+@media (max-width: 991.98px) {
+    .track-collection {
+        max-height: none;
+    }
+
+    .player-bar {
+        position: static;
+        border-radius: 24px 24px 0 0;
+        margin-top: 2rem;
+    }
+}
+
+@media (max-width: 575.98px) {
+    .track-cover {
+        width: 48px;
+        height: 48px;
+    }
+
+    .player-cover-sm {
+        width: 56px;
+        height: 56px;
+    }
+
+    .btn-circle {
+        width: 38px;
+        height: 38px;
+    }
+
+    .btn-circle.primary {
+        width: 46px;
+        height: 46px;
+    }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,434 @@
+(function () {
+    const playerRoot = document.querySelector('[data-player-root]');
+    if (!playerRoot) {
+        return;
+    }
+
+    let tracks = [];
+    try {
+        tracks = JSON.parse(playerRoot.dataset.tracks || '[]');
+        if (!Array.isArray(tracks)) {
+            tracks = [];
+        }
+    } catch (error) {
+        console.warn('Не удалось разобрать список треков', error);
+        tracks = [];
+    }
+
+    const audio = playerRoot.querySelector('[data-audio]');
+    if (!(audio instanceof HTMLAudioElement)) {
+        return;
+    }
+
+    const defaultCover = playerRoot.dataset.defaultCover || '';
+    const trackList = playerRoot.querySelector('[data-track-list]');
+    const trackItems = trackList ? Array.from(trackList.querySelectorAll('[data-track-index]')) : [];
+
+    const coverEl = playerRoot.querySelector('[data-current-cover]');
+    const titleEl = playerRoot.querySelector('[data-current-title]');
+    const metaEl = playerRoot.querySelector('[data-current-meta]');
+    const currentTimeEl = playerRoot.querySelector('[data-current-time]');
+    const durationEl = playerRoot.querySelector('[data-duration]');
+    const progressEl = playerRoot.querySelector('[data-progress]');
+    const volumeEl = playerRoot.querySelector('[data-volume]');
+    const playButton = playerRoot.querySelector('[data-control="play"]');
+    const nextButton = playerRoot.querySelector('[data-control="next"]');
+    const prevButton = playerRoot.querySelector('[data-control="prev"]');
+    const shuffleButton = playerRoot.querySelector('[data-control="shuffle"]');
+    const filterButtons = Array.from(playerRoot.querySelectorAll('[data-filter-group]'));
+
+    const state = {
+        currentIndex: tracks.length ? 0 : -1,
+        shuffle: false,
+        history: [],
+        filters: {
+            artist: null,
+            album: null,
+        },
+        queue: [],
+        isPlaying: false,
+    };
+
+    function formatTime(value) {
+        if (typeof value !== 'number' || !isFinite(value) || value < 0) {
+            return '0:00';
+        }
+        const totalSeconds = Math.floor(value);
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = totalSeconds % 60;
+        return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+    }
+
+    function updatePlayButton(isPlaying) {
+        state.isPlaying = isPlaying;
+        if (!(playButton instanceof HTMLElement)) {
+            return;
+        }
+        const icon = playButton.querySelector('i');
+        if (!icon) {
+            return;
+        }
+        if (isPlaying) {
+            playButton.setAttribute('aria-label', 'Пауза');
+            icon.classList.remove('bi-play-fill');
+            icon.classList.add('bi-pause-fill');
+        } else {
+            playButton.setAttribute('aria-label', 'Воспроизвести');
+            icon.classList.remove('bi-pause-fill');
+            icon.classList.add('bi-play-fill');
+        }
+    }
+
+    function highlightActiveTrack() {
+        trackItems.forEach((item) => {
+            if (!(item instanceof HTMLElement)) {
+                return;
+            }
+            const index = Number.parseInt(item.dataset.trackIndex || '-1', 10);
+            if (index === state.currentIndex) {
+                item.classList.add('active');
+            } else {
+                item.classList.remove('active');
+            }
+        });
+    }
+
+    function updateCurrentInfo(track) {
+        if (coverEl instanceof HTMLImageElement) {
+            coverEl.src = track.coverUrl || defaultCover;
+        }
+        if (titleEl) {
+            titleEl.textContent = track.title || 'Неизвестный трек';
+        }
+        if (metaEl) {
+            metaEl.textContent = `${track.artist || ''}${track.artist && track.album ? ' • ' : ''}${track.album || ''}`.trim();
+        }
+        if (durationEl) {
+            const displayDuration = typeof track.duration === 'number' && track.duration > 0 ? formatTime(track.duration) : track.duration_formatted || '0:00';
+            durationEl.textContent = displayDuration;
+        }
+        if (currentTimeEl) {
+            currentTimeEl.textContent = '0:00';
+        }
+        if (progressEl instanceof HTMLInputElement) {
+            progressEl.value = '0';
+        }
+    }
+
+    function resetCurrentInfo() {
+        if (coverEl instanceof HTMLImageElement) {
+            coverEl.src = defaultCover;
+        }
+        if (titleEl) {
+            titleEl.textContent = 'Выберите трек';
+        }
+        if (metaEl) {
+            metaEl.textContent = '';
+        }
+        if (currentTimeEl) {
+            currentTimeEl.textContent = '0:00';
+        }
+        if (durationEl) {
+            durationEl.textContent = '0:00';
+        }
+        if (progressEl instanceof HTMLInputElement) {
+            progressEl.value = '0';
+        }
+    }
+
+    function refreshQueue() {
+        const visibleIndices = trackItems
+            .filter((item) => item instanceof HTMLElement && !item.classList.contains('d-none'))
+            .map((item) => Number.parseInt(item.dataset.trackIndex || '-1', 10))
+            .filter((index) => Number.isInteger(index) && index >= 0 && index < tracks.length);
+        state.queue = visibleIndices;
+    }
+
+    function ensureCurrentTrackVisible() {
+        if (state.currentIndex === -1) {
+            return;
+        }
+        const currentItem = trackItems.find((item) => Number.parseInt(item.dataset.trackIndex || '-1', 10) === state.currentIndex);
+        if (currentItem instanceof HTMLElement && currentItem.classList.contains('d-none')) {
+            audio.pause();
+            state.currentIndex = -1;
+            updatePlayButton(false);
+            resetCurrentInfo();
+        }
+    }
+
+    function applyFilters(group, value) {
+        state.filters[group] = value || null;
+        trackItems.forEach((item) => {
+            if (!(item instanceof HTMLElement)) {
+                return;
+            }
+            const trackIndex = Number.parseInt(item.dataset.trackIndex || '-1', 10);
+            if (!Number.isInteger(trackIndex) || trackIndex < 0 || trackIndex >= tracks.length) {
+                item.classList.add('d-none');
+                return;
+            }
+            const track = tracks[trackIndex];
+            const matchesArtist = !state.filters.artist || track.artist === state.filters.artist;
+            const matchesAlbum = !state.filters.album || track.album === state.filters.album;
+            if (matchesArtist && matchesAlbum) {
+                item.classList.remove('d-none');
+            } else {
+                item.classList.add('d-none');
+            }
+        });
+        refreshQueue();
+        ensureCurrentTrackVisible();
+        if (!state.queue.length) {
+            audio.pause();
+            updatePlayButton(false);
+            resetCurrentInfo();
+        }
+    }
+
+    function setShuffle(enabled) {
+        state.shuffle = enabled;
+        if (shuffleButton instanceof HTMLElement) {
+            shuffleButton.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+        }
+    }
+
+    function updateDurationDisplay(index, duration) {
+        const item = trackItems.find((element) => Number.parseInt(element.dataset.trackIndex || '-1', 10) === index);
+        if (!item) {
+            return;
+        }
+        const target = item.querySelector('[data-duration]');
+        if (target) {
+            target.textContent = formatTime(duration);
+        }
+    }
+
+    function loadTrack(index, autoPlay = false, pushHistory = true) {
+        if (!Number.isInteger(index) || index < 0 || index >= tracks.length) {
+            return;
+        }
+        if (!state.queue.includes(index)) {
+            return;
+        }
+        if (pushHistory && state.currentIndex !== -1 && state.currentIndex !== index) {
+            state.history.push(state.currentIndex);
+            if (state.history.length > 50) {
+                state.history.shift();
+            }
+        }
+        state.currentIndex = index;
+        const track = tracks[index];
+        audio.src = track.audioUrl;
+        audio.load();
+        updateCurrentInfo(track);
+        highlightActiveTrack();
+        if (autoPlay) {
+            audio.play().catch(() => {
+                updatePlayButton(false);
+            });
+        }
+    }
+
+    function playNext(autoPlay = true) {
+        if (!state.queue.length) {
+            return;
+        }
+        if (state.currentIndex === -1) {
+            loadTrack(state.queue[0], autoPlay, true);
+            return;
+        }
+        let nextIndex = state.currentIndex;
+        if (state.shuffle) {
+            const candidates = state.queue.filter((value) => value !== state.currentIndex);
+            if (candidates.length === 0) {
+                nextIndex = state.currentIndex;
+            } else {
+                nextIndex = candidates[Math.floor(Math.random() * candidates.length)];
+            }
+        } else {
+            const position = state.queue.indexOf(state.currentIndex);
+            if (position === -1 || position === state.queue.length - 1) {
+                nextIndex = state.queue[0];
+            } else {
+                nextIndex = state.queue[position + 1];
+            }
+        }
+        loadTrack(nextIndex, autoPlay, true);
+    }
+
+    function playPrevious() {
+        if (!state.queue.length) {
+            return;
+        }
+        if (state.shuffle && state.history.length) {
+            const previousIndex = state.history.pop();
+            loadTrack(previousIndex, true, false);
+            return;
+        }
+        if (state.currentIndex === -1) {
+            loadTrack(state.queue[0], false, false);
+            return;
+        }
+        const position = state.queue.indexOf(state.currentIndex);
+        let previousIndex;
+        if (position <= 0) {
+            previousIndex = state.queue[state.queue.length - 1];
+        } else {
+            previousIndex = state.queue[position - 1];
+        }
+        loadTrack(previousIndex, true, false);
+    }
+
+    function togglePlay() {
+        if (state.currentIndex === -1 && state.queue.length) {
+            loadTrack(state.queue[0], true, false);
+            return;
+        }
+        if (audio.paused) {
+            audio.play().catch(() => {
+                updatePlayButton(false);
+            });
+        } else {
+            audio.pause();
+        }
+    }
+
+    function preloadDurations() {
+        tracks.forEach((track, index) => {
+            if (typeof track.duration === 'number' && track.duration > 0) {
+                updateDurationDisplay(index, track.duration);
+                return;
+            }
+            const probe = new Audio();
+            probe.preload = 'metadata';
+            probe.src = track.audioUrl;
+            const cleanup = () => {
+                probe.src = '';
+            };
+            probe.addEventListener('loadedmetadata', () => {
+                const duration = Number.isFinite(probe.duration) ? Math.round(probe.duration) : 0;
+                if (duration > 0) {
+                    tracks[index].duration = duration;
+                    updateDurationDisplay(index, duration);
+                    if (index === state.currentIndex && durationEl) {
+                        durationEl.textContent = formatTime(duration);
+                    }
+                }
+                cleanup();
+            }, { once: true });
+            probe.addEventListener('error', cleanup, { once: true });
+        });
+    }
+
+    if (progressEl instanceof HTMLInputElement) {
+        progressEl.addEventListener('input', (event) => {
+            if (!audio.duration) {
+                return;
+            }
+            const input = event.target;
+            const percent = Number.parseFloat(input.value || '0');
+            audio.currentTime = (Math.max(0, Math.min(100, percent)) / 100) * audio.duration;
+        });
+    }
+
+    if (volumeEl instanceof HTMLInputElement) {
+        const initialVolume = Number.parseFloat(volumeEl.value || '80') / 100;
+        audio.volume = Math.max(0, Math.min(1, initialVolume));
+        volumeEl.addEventListener('input', (event) => {
+            const value = Number.parseFloat(event.target.value || '0');
+            audio.volume = Math.max(0, Math.min(1, value / 100));
+        });
+    }
+
+    if (playButton instanceof HTMLElement) {
+        playButton.addEventListener('click', togglePlay);
+    }
+    if (nextButton instanceof HTMLElement) {
+        nextButton.addEventListener('click', () => playNext(true));
+    }
+    if (prevButton instanceof HTMLElement) {
+        prevButton.addEventListener('click', playPrevious);
+    }
+    if (shuffleButton instanceof HTMLElement) {
+        shuffleButton.addEventListener('click', () => {
+            setShuffle(!state.shuffle);
+        });
+    }
+
+    trackItems.forEach((item) => {
+        if (!(item instanceof HTMLElement)) {
+            return;
+        }
+        item.addEventListener('click', () => {
+            const index = Number.parseInt(item.dataset.trackIndex || '-1', 10);
+            if (!Number.isInteger(index)) {
+                return;
+            }
+            if (!state.queue.includes(index)) {
+                return;
+            }
+            const shouldAutoplay = state.currentIndex === index ? audio.paused : true;
+            loadTrack(index, shouldAutoplay, true);
+        });
+    });
+
+    filterButtons.forEach((button) => {
+        if (!(button instanceof HTMLElement)) {
+            return;
+        }
+        const group = button.dataset.filterGroup;
+        if (!group) {
+            return;
+        }
+        button.addEventListener('click', () => {
+            filterButtons
+                .filter((element) => element.dataset.filterGroup === group)
+                .forEach((element) => element.classList.remove('active'));
+            button.classList.add('active');
+            applyFilters(group, button.dataset.filterValue || '');
+        });
+    });
+
+    audio.addEventListener('play', () => updatePlayButton(true));
+    audio.addEventListener('pause', () => updatePlayButton(false));
+    audio.addEventListener('timeupdate', () => {
+        if (!audio.duration) {
+            return;
+        }
+        if (currentTimeEl) {
+            currentTimeEl.textContent = formatTime(audio.currentTime);
+        }
+        if (progressEl instanceof HTMLInputElement) {
+            const percent = (audio.currentTime / audio.duration) * 100;
+            progressEl.value = String(Math.min(100, Math.max(0, percent)));
+        }
+    });
+    audio.addEventListener('loadedmetadata', () => {
+        if (!Number.isFinite(audio.duration) || audio.duration <= 0) {
+            return;
+        }
+        const rounded = Math.round(audio.duration);
+        if (state.currentIndex >= 0 && state.currentIndex < tracks.length) {
+            tracks[state.currentIndex].duration = rounded;
+        }
+        if (durationEl) {
+            durationEl.textContent = formatTime(audio.duration);
+        }
+        if (progressEl instanceof HTMLInputElement) {
+            progressEl.value = '0';
+        }
+    });
+    audio.addEventListener('ended', () => playNext(true));
+    audio.addEventListener('error', () => {
+        updatePlayButton(false);
+    });
+
+    refreshQueue();
+    if (state.queue.length) {
+        loadTrack(state.queue[0], false, false);
+    } else {
+        resetCurrentInfo();
+    }
+    preloadDurations();
+})();

--- a/public/images/default-cover.svg
+++ b/public/images/default-cover.svg
@@ -1,0 +1,13 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ff6b6b"/>
+      <stop offset="100%" stop-color="#845ef7"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="240" height="240" rx="32" fill="url(#grad)"/>
+  <g opacity="0.9" fill="#ffffff">
+    <circle cx="96" cy="120" r="18"/>
+    <path d="M144 72c-4.418 0-8 3.582-8 8v60.07c-3.413-1.89-7.29-3.07-11.48-3.07-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24V104h12c4.418 0 8-3.582 8-8s-3.582-8-8-8h-12V80c0-4.418-3.582-8-8-8z"/>
+  </g>
+</svg>

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Entity\src\Kernel;
+use App\Kernel;
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 

--- a/public/uploads/.gitignore
+++ b/public/uploads/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -2,6 +2,9 @@
 
 namespace App\Controller;
 
+use App\Entity\Track;
+use App\Repository\TrackRepository;
+use App\Service\TrackManager;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -9,8 +12,42 @@ use Symfony\Component\Routing\Annotation\Route;
 class DefaultController extends AbstractController
 {
     #[Route('/', name: 'home')]
-    public function index(): Response
+    public function index(TrackRepository $trackRepository): Response
     {
-        return $this->render('home/index.html.twig');
+        $tracks = $trackRepository->findBy([], ['id' => 'DESC']);
+
+        return $this->render('home/index.html.twig', [
+            'tracks' => $tracks,
+            'artistCounts' => $this->groupByCounts($tracks, static fn (Track $track): ?string => $track->getArtist(), TrackManager::UNKNOWN_ARTIST),
+            'albumCounts' => $this->groupByCounts($tracks, static fn (Track $track): ?string => $track->getAlbum(), TrackManager::UNKNOWN_ALBUM),
+            'defaults' => [
+                'title' => TrackManager::UNKNOWN_TITLE,
+                'artist' => TrackManager::UNKNOWN_ARTIST,
+                'album' => TrackManager::UNKNOWN_ALBUM,
+            ],
+        ]);
+    }
+
+    /**
+     * @param array<int, Track> $tracks
+     * @return array<string, int>
+     */
+    private function groupByCounts(array $tracks, callable $accessor, string $fallback): array
+    {
+        $counts = [];
+
+        foreach ($tracks as $track) {
+            $value = $accessor($track);
+            $value = is_string($value) ? trim($value) : '';
+            if ($value === '') {
+                $value = $fallback;
+            }
+
+            $counts[$value] = ($counts[$value] ?? 0) + 1;
+        }
+
+        ksort($counts, SORT_NATURAL | SORT_FLAG_CASE);
+
+        return $counts;
     }
 }

--- a/src/Controller/TrackController.php
+++ b/src/Controller/TrackController.php
@@ -2,9 +2,10 @@
 
 namespace App\Controller;
 
-use App\Repository\TrackRepository;
 use App\Entity\Track;
 use App\Form\TrackType;
+use App\Repository\TrackRepository;
+use App\Service\TrackManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -17,21 +18,41 @@ class TrackController extends AbstractController
     #[Route('/', name: 'app_track_index', methods: ['GET'])]
     public function index(TrackRepository $trackRepository): Response
     {
+        $tracks = $trackRepository->findBy([], ['id' => 'DESC']);
+
         return $this->render('track/index.html.twig', [
-            'tracks' => $trackRepository->findAll(),
+            'tracks' => $tracks,
+            'defaults' => [
+                'title' => TrackManager::UNKNOWN_TITLE,
+                'artist' => TrackManager::UNKNOWN_ARTIST,
+                'album' => TrackManager::UNKNOWN_ALBUM,
+            ],
         ]);
     }
 
     #[Route('/new', name: 'app_track_new', methods: ['GET', 'POST'])]
-    public function new(Request $request, EntityManagerInterface $entityManager): Response
+    public function new(Request $request, EntityManagerInterface $entityManager, TrackManager $trackManager): Response
     {
         $track = new Track();
-        $form = $this->createForm(TrackType::class, $track);
+        $form = $this->createForm(TrackType::class, $track, [
+            'require_audio_file' => true,
+        ]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $audioFile = $form->get('audioFile')->getData();
+
+            if ($audioFile) {
+                $trackManager->handleUpload($track, $audioFile);
+                $trackManager->ensureDefaults($track, $audioFile->getClientOriginalName());
+            } else {
+                $trackManager->ensureDefaults($track);
+            }
+
             $entityManager->persist($track);
             $entityManager->flush();
+
+            $this->addFlash('success', 'Трек успешно добавлен.');
 
             return $this->redirectToRoute('app_track_index', [], Response::HTTP_SEE_OTHER);
         }
@@ -39,6 +60,11 @@ class TrackController extends AbstractController
         return $this->renderForm('track/new.html.twig', [
             'track' => $track,
             'form' => $form,
+            'defaults' => [
+                'title' => TrackManager::UNKNOWN_TITLE,
+                'artist' => TrackManager::UNKNOWN_ARTIST,
+                'album' => TrackManager::UNKNOWN_ALBUM,
+            ],
         ]);
     }
 
@@ -47,17 +73,33 @@ class TrackController extends AbstractController
     {
         return $this->render('track/show.html.twig', [
             'track' => $track,
+            'defaults' => [
+                'title' => TrackManager::UNKNOWN_TITLE,
+                'artist' => TrackManager::UNKNOWN_ARTIST,
+                'album' => TrackManager::UNKNOWN_ALBUM,
+            ],
         ]);
     }
 
     #[Route('/{id}/edit', name: 'app_track_edit', methods: ['GET', 'POST'])]
-    public function edit(Request $request, Track $track, EntityManagerInterface $entityManager): Response
+    public function edit(Request $request, Track $track, EntityManagerInterface $entityManager, TrackManager $trackManager): Response
     {
         $form = $this->createForm(TrackType::class, $track);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $audioFile = $form->get('audioFile')->getData();
+
+            if ($audioFile) {
+                $trackManager->handleUpload($track, $audioFile, true);
+                $trackManager->ensureDefaults($track, $audioFile->getClientOriginalName());
+            } else {
+                $trackManager->ensureDefaults($track);
+            }
+
             $entityManager->flush();
+
+            $this->addFlash('success', 'Трек обновлён.');
 
             return $this->redirectToRoute('app_track_index', [], Response::HTTP_SEE_OTHER);
         }
@@ -65,15 +107,23 @@ class TrackController extends AbstractController
         return $this->renderForm('track/edit.html.twig', [
             'track' => $track,
             'form' => $form,
+            'defaults' => [
+                'title' => TrackManager::UNKNOWN_TITLE,
+                'artist' => TrackManager::UNKNOWN_ARTIST,
+                'album' => TrackManager::UNKNOWN_ALBUM,
+            ],
         ]);
     }
 
     #[Route('/{id}', name: 'app_track_delete', methods: ['POST'])]
-    public function delete(Request $request, Track $track, EntityManagerInterface $entityManager): Response
+    public function delete(Request $request, Track $track, EntityManagerInterface $entityManager, TrackManager $trackManager): Response
     {
         if ($this->isCsrfTokenValid('delete'.$track->getId(), $request->request->get('_token'))) {
+            $trackManager->removeMedia($track);
             $entityManager->remove($track);
             $entityManager->flush();
+
+            $this->addFlash('success', 'Трек удалён.');
         }
 
         return $this->redirectToRoute('app_track_index', [], Response::HTTP_SEE_OTHER);

--- a/src/Entity/Track.php
+++ b/src/Entity/Track.php
@@ -16,10 +16,10 @@ class Track
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $title = null;
 
-    #[ORM\Column(length: 255)]
+    #[ORM\Column(length: 255, nullable: true)]
     private ?string $artist = null;
 
-    #[ORM\Column]
+    #[ORM\Column(nullable: true)]
     private ?int $duration = null;
 
     #[ORM\Column(length: 255)]
@@ -56,7 +56,7 @@ class Track
         return $this->artist;
     }
 
-    public function setArtist(string $artist): static
+    public function setArtist(?string $artist): static
     {
         $this->artist = $artist;
 
@@ -68,7 +68,7 @@ class Track
         return $this->duration;
     }
 
-    public function setDuration(int $duration): static
+    public function setDuration(?int $duration): static
     {
         $this->duration = $duration;
 
@@ -121,5 +121,17 @@ class Track
         $this->coverImage = $coverImage;
 
         return $this;
+    }
+
+    public function getFormattedDuration(): ?string
+    {
+        if ($this->duration === null) {
+            return null;
+        }
+
+        $seconds = max(0, $this->duration);
+        $format = $seconds >= 3600 ? 'H:i:s' : 'i:s';
+
+        return gmdate($format, $seconds);
     }
 }

--- a/src/Form/TrackType.php
+++ b/src/Form/TrackType.php
@@ -4,21 +4,69 @@ namespace App\Form;
 
 use App\Entity\Track;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\File;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 class TrackType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $audioConstraints = [
+            new File([
+                'mimeTypes' => [
+                    'audio/mpeg',
+                    'audio/mp3',
+                    'audio/x-mpeg',
+                    'audio/aac',
+                    'audio/wav',
+                    'audio/x-wav',
+                    'audio/ogg',
+                    'audio/flac',
+                    'audio/webm',
+                    'audio/x-ms-wma',
+                ],
+                'mimeTypesMessage' => 'Пожалуйста, загрузите корректный аудиофайл.',
+            ]),
+        ];
+
+        if ($options['require_audio_file']) {
+            $audioConstraints[] = new NotBlank([
+                'message' => 'Добавьте аудиофайл.',
+            ]);
+        }
+
         $builder
-            ->add('title')
-            ->add('artist')
-            ->add('duration')
-            ->add('filePath')
-            ->add('album')
-            ->add('genre')
-            ->add('coverImage')
+            ->add('audioFile', FileType::class, [
+                'label' => 'Аудиофайл',
+                'mapped' => false,
+                'required' => $options['require_audio_file'],
+                'help' => 'MP3, WAV, OGG, FLAC, AAC, WEBM',
+                'constraints' => $audioConstraints,
+            ])
+            ->add('title', TextType::class, [
+                'required' => false,
+                'label' => 'Название',
+                'attr' => ['placeholder' => 'Название трека'],
+            ])
+            ->add('artist', TextType::class, [
+                'required' => false,
+                'label' => 'Исполнитель',
+                'attr' => ['placeholder' => 'Имя артиста'],
+            ])
+            ->add('album', TextType::class, [
+                'required' => false,
+                'label' => 'Альбом',
+                'attr' => ['placeholder' => 'Название альбома'],
+            ])
+            ->add('genre', TextType::class, [
+                'required' => false,
+                'label' => 'Жанр',
+                'attr' => ['placeholder' => 'Жанр композиции'],
+            ])
         ;
     }
 
@@ -26,6 +74,7 @@ class TrackType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => Track::class,
+            'require_audio_file' => false,
         ]);
     }
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App;
+
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+
+    protected function configureContainer(ContainerConfigurator $container): void
+    {
+        $container->import('../config/{packages}/*.yaml');
+        $container->import('../config/{packages}/'.$this->environment.'/*.yaml');
+
+        if (is_file(\dirname(__DIR__).'/config/services.yaml')) {
+            $container->import('../config/{services}.yaml');
+            $container->import('../config/{services}_'.$this->environment.'.yaml');
+        } elseif (is_file($path = \dirname(__DIR__).'/config/services.php')) {
+            (require $path)($container->withPath($path), $this);
+        }
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        $routes->import('../config/{routes}/'.$this->environment.'/*.yaml');
+        $routes->import('../config/{routes}/*.yaml');
+
+        if (is_file(\dirname(__DIR__).'/config/routes.yaml')) {
+            $routes->import('../config/routes.yaml');
+        } elseif (is_file($path = \dirname(__DIR__).'/config/routes.php')) {
+            (require $path)($routes->withPath($path), $this);
+        }
+    }
+}

--- a/src/Service/Audio/AudioCover.php
+++ b/src/Service/Audio/AudioCover.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Service\Audio;
+
+final class AudioCover
+{
+    public function __construct(
+        private readonly string $mimeType,
+        private readonly string $binaryData
+    ) {
+    }
+
+    public function getMimeType(): string
+    {
+        return $this->mimeType;
+    }
+
+    public function getBinaryData(): string
+    {
+        return $this->binaryData;
+    }
+}

--- a/src/Service/Audio/AudioMetadata.php
+++ b/src/Service/Audio/AudioMetadata.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Service\Audio;
+
+final class AudioMetadata
+{
+    public function __construct(
+        private readonly ?string $title,
+        private readonly ?string $artist,
+        private readonly ?string $album,
+        private readonly ?string $genre,
+        private readonly ?int $duration,
+        private readonly ?AudioCover $cover
+    ) {
+    }
+
+    public static function empty(): self
+    {
+        return new self(null, null, null, null, null, null);
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function getArtist(): ?string
+    {
+        return $this->artist;
+    }
+
+    public function getAlbum(): ?string
+    {
+        return $this->album;
+    }
+
+    public function getGenre(): ?string
+    {
+        return $this->genre;
+    }
+
+    public function getDuration(): ?int
+    {
+        return $this->duration;
+    }
+
+    public function getCover(): ?AudioCover
+    {
+        return $this->cover;
+    }
+}

--- a/src/Service/Audio/AudioMetadataReader.php
+++ b/src/Service/Audio/AudioMetadataReader.php
@@ -1,0 +1,314 @@
+<?php
+
+namespace App\Service\Audio;
+
+use function array_key_exists;
+use function array_merge;
+use function fclose;
+use function fopen;
+use function fread;
+use function fseek;
+use function is_file;
+use function is_numeric;
+use function is_readable;
+use function mb_convert_encoding;
+use function ord;
+use function preg_match;
+use function strlen;
+use function strpos;
+use function substr;
+use const SEEK_END;
+
+class AudioMetadataReader
+{
+    private const GENRES = [
+        'Blues', 'Classic Rock', 'Country', 'Dance', 'Disco', 'Funk', 'Grunge', 'Hip-Hop', 'Jazz', 'Metal',
+        'New Age', 'Oldies', 'Other', 'Pop', 'R&B', 'Rap', 'Reggae', 'Rock', 'Techno', 'Industrial',
+        'Alternative', 'Ska', 'Death Metal', 'Pranks', 'Soundtrack', 'Euro-Techno', 'Ambient', 'Trip-Hop', 'Vocal', 'Jazz+Funk',
+        'Fusion', 'Trance', 'Classical', 'Instrumental', 'Acid', 'House', 'Game', 'Sound Clip', 'Gospel', 'Noise',
+        'Alternative Rock', 'Bass', 'Soul', 'Punk', 'Space', 'Meditative', 'Instrumental Pop', 'Instrumental Rock', 'Ethnic', 'Gothic',
+        'Darkwave', 'Techno-Industrial', 'Electronic', 'Pop-Folk', 'Eurodance', 'Dream', 'Southern Rock', 'Comedy', 'Cult', 'Gangsta',
+        'Top 40', 'Christian Rap', 'Pop/Funk', 'Jungle', 'Native US', 'Cabaret', 'New Wave', 'Psychadelic', 'Rave', 'Showtunes',
+        'Trailer', 'Lo-Fi', 'Tribal', 'Acid Punk', 'Acid Jazz', 'Polka', 'Retro', 'Musical', 'Rock & Roll', 'Hard Rock',
+        'Folk', 'Folk-Rock', 'National Folk', 'Swing', 'Fast Fusion', 'Bebob', 'Latin', 'Revival', 'Celtic', 'Bluegrass',
+        'Avantgarde', 'Gothic Rock', 'Progressive Rock', 'Psychedelic Rock', 'Symphonic Rock', 'Slow Rock', 'Big Band', 'Chorus', 'Easy Listening', 'Acoustic',
+        'Humour', 'Speech', 'Chanson', 'Opera', 'Chamber Music', 'Sonata', 'Symphony', 'Booty Bass', 'Primus', 'Porn Groove',
+        'Satire', 'Slow Jam', 'Club', 'Tango', 'Samba', 'Folklore', 'Ballad', 'Power Ballad', 'Rhythmic Soul', 'Freestyle',
+        'Duet', 'Punk Rock', 'Drum Solo', 'Acapella', 'Euro-House', 'Dance Hall'
+    ];
+
+    public function extract(string $filePath): AudioMetadata
+    {
+        if (!is_file($filePath) || !is_readable($filePath)) {
+            return AudioMetadata::empty();
+        }
+
+        $metadata = $this->readId3v2($filePath);
+        $fallback = $this->readId3v1($filePath);
+        $merged = array_merge($fallback, $metadata);
+
+        return new AudioMetadata(
+            $this->sanitizeString($merged['title'] ?? null),
+            $this->sanitizeString($merged['artist'] ?? null),
+            $this->sanitizeString($merged['album'] ?? null),
+            $this->sanitizeString($merged['genre'] ?? null),
+            isset($merged['duration']) && is_numeric($merged['duration']) ? (int) $merged['duration'] : null,
+            $merged['cover'] ?? null
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readId3v2(string $filePath): array
+    {
+        $handle = @fopen($filePath, 'rb');
+        if (!$handle) {
+            return [];
+        }
+
+        $header = fread($handle, 10);
+        if (strlen($header) < 10 || substr($header, 0, 3) !== 'ID3') {
+            fclose($handle);
+            return [];
+        }
+
+        $version = ord($header[3]);
+        $size = $this->decodeSyncSafe(substr($header, 6, 4));
+        $tagData = fread($handle, $size);
+        fclose($handle);
+
+        $offset = 0;
+        $result = [];
+        $length = strlen($tagData);
+
+        while ($offset + 10 <= $length) {
+            $frameId = substr($tagData, $offset, 4);
+            if ($frameId === "\0\0\0\0" || trim($frameId) === '') {
+                break;
+            }
+
+            $rawSize = substr($tagData, $offset + 4, 4);
+            $frameSize = $version >= 4 ? $this->decodeSyncSafe($rawSize) : $this->decodeBigEndian($rawSize);
+
+            if ($frameSize <= 0 || $offset + 10 + $frameSize > $length) {
+                break;
+            }
+
+            $frameData = substr($tagData, $offset + 10, $frameSize);
+            $offset += 10 + $frameSize;
+
+            switch ($frameId) {
+                case 'TIT2':
+                    $result['title'] = $this->decodeTextFrame($frameData);
+                    break;
+                case 'TPE1':
+                    $result['artist'] = $this->decodeTextFrame($frameData);
+                    break;
+                case 'TALB':
+                    $result['album'] = $this->decodeTextFrame($frameData);
+                    break;
+                case 'TCON':
+                    $result['genre'] = $this->normalizeGenre($this->decodeTextFrame($frameData));
+                    break;
+                case 'TLEN':
+                    $durationText = $this->decodeTextFrame($frameData);
+                    if ($durationText && is_numeric($durationText)) {
+                        $result['duration'] = (int) round(((int) $durationText) / 1000);
+                    }
+                    break;
+                case 'APIC':
+                    $cover = $this->extractCover($frameData);
+                    if ($cover) {
+                        $result['cover'] = $cover;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readId3v1(string $filePath): array
+    {
+        $handle = @fopen($filePath, 'rb');
+        if (!$handle) {
+            return [];
+        }
+
+        if (fseek($handle, -128, SEEK_END) !== 0) {
+            fclose($handle);
+            return [];
+        }
+
+        $buffer = fread($handle, 128);
+        fclose($handle);
+
+        if (strlen($buffer) !== 128 || substr($buffer, 0, 3) !== 'TAG') {
+            return [];
+        }
+
+        $title = $this->trimNullBytes(substr($buffer, 3, 30));
+        $artist = $this->trimNullBytes(substr($buffer, 33, 30));
+        $album = $this->trimNullBytes(substr($buffer, 63, 30));
+        $genreIndex = ord($buffer[127]);
+        $genre = self::GENRES[$genreIndex] ?? null;
+
+        return array_filter([
+            'title' => $title ?: null,
+            'artist' => $artist ?: null,
+            'album' => $album ?: null,
+            'genre' => $genre,
+        ], static fn ($value) => $value !== null);
+    }
+
+    private function decodeSyncSafe(string $bytes): int
+    {
+        $value = 0;
+        $length = strlen($bytes);
+        for ($i = 0; $i < $length; ++$i) {
+            $value = ($value << 7) | (ord($bytes[$i]) & 0x7F);
+        }
+
+        return $value;
+    }
+
+    private function decodeBigEndian(string $bytes): int
+    {
+        $unpacked = unpack('N', $bytes);
+
+        return $unpacked ? (int) $unpacked[1] : 0;
+    }
+
+    private function decodeTextFrame(string $data): ?string
+    {
+        if ($data === '') {
+            return null;
+        }
+
+        $encoding = ord($data[0]);
+        $content = substr($data, 1);
+
+        return $this->convertEncoding($content, $encoding);
+    }
+
+    private function normalizeGenre(?string $genre): ?string
+    {
+        if ($genre === null) {
+            return null;
+        }
+
+        $clean = trim(str_replace(['\\0', "\0"], '', $genre));
+        if ($clean === '') {
+            return null;
+        }
+
+        if (preg_match('/\((\d+)\)/', $clean, $matches)) {
+            $index = (int) $matches[1];
+            if (array_key_exists($index, self::GENRES)) {
+                return self::GENRES[$index];
+            }
+        }
+
+        return trim($clean, ' ()');
+    }
+
+    private function extractCover(string $frameData): ?AudioCover
+    {
+        if ($frameData === '') {
+            return null;
+        }
+
+        $encoding = ord($frameData[0]);
+        $offset = 1;
+        $mimeEnd = strpos($frameData, "\0", $offset);
+        if ($mimeEnd === false) {
+            return null;
+        }
+
+        $mime = substr($frameData, $offset, $mimeEnd - $offset) ?: 'image/jpeg';
+        $offset = $mimeEnd + 1;
+
+        if ($offset >= strlen($frameData)) {
+            return null;
+        }
+
+        $offset += 1; // skip picture type
+
+        $termination = ($encoding === 1 || $encoding === 2) ? "\0\0" : "\0";
+        $descriptionEnd = strpos($frameData, $termination, $offset);
+        if ($descriptionEnd === false) {
+            $descriptionEnd = $offset;
+        }
+
+        $offset = $descriptionEnd + strlen($termination);
+        $binary = substr($frameData, $offset);
+
+        if ($binary === '') {
+            return null;
+        }
+
+        return new AudioCover($mime, $binary);
+    }
+
+    private function convertEncoding(string $text, int $encoding): ?string
+    {
+        $text = str_replace("\0", '', $text);
+        if ($text === '') {
+            return null;
+        }
+
+        return match ($encoding) {
+            0 => $this->toUtf8($text, 'ISO-8859-1'),
+            1 => $this->toUtf8($text, 'UTF-16'),
+            2 => $this->toUtf8($text, 'UTF-16BE'),
+            3 => $this->toUtf8($text, 'UTF-8'),
+            default => $this->toUtf8($text, 'UTF-8'),
+        };
+    }
+
+    private function toUtf8(string $text, string $sourceEncoding): ?string
+    {
+        if ($text === '') {
+            return null;
+        }
+
+        $converted = false;
+        if (function_exists('mb_convert_encoding')) {
+            $converted = @mb_convert_encoding($text, 'UTF-8', $sourceEncoding);
+        }
+
+        if ($converted === false && function_exists('iconv')) {
+            $converted = @iconv($sourceEncoding, 'UTF-8//IGNORE', $text);
+        }
+
+        $result = $converted !== false ? $converted : $text;
+        $result = trim(str_replace("\0", '', $result));
+
+        return $result !== '' ? $result : null;
+    }
+
+    private function trimNullBytes(string $value): string
+    {
+        return trim(str_replace("\0", '', $value));
+    }
+
+    private function sanitizeString(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+
+        return $value;
+    }
+}

--- a/src/Service/TrackManager.php
+++ b/src/Service/TrackManager.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Track;
+use App\Service\Audio\AudioCover;
+use App\Service\Audio\AudioMetadata;
+use App\Service\Audio\AudioMetadataReader;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\String\Slugger\SluggerInterface;
+use function function_exists;
+use function mb_convert_case;
+use function pathinfo;
+use function preg_replace;
+use function rtrim;
+use function str_replace;
+use function strtolower;
+use function trim;
+use function ucwords;
+use const MB_CASE_TITLE;
+use const PATHINFO_FILENAME;
+
+class TrackManager
+{
+    public const UNKNOWN_TITLE = 'Без названия';
+    public const UNKNOWN_ARTIST = 'Неизвестный исполнитель';
+    public const UNKNOWN_ALBUM = 'Неизвестный альбом';
+
+    private Filesystem $filesystem;
+
+    public function __construct(
+        private readonly AudioMetadataReader $metadataReader,
+        private readonly SluggerInterface $slugger,
+        private readonly string $tracksDirectory,
+        private readonly string $coversDirectory,
+        private readonly string $projectDirectory
+    ) {
+        $this->filesystem = new Filesystem();
+        $this->filesystem->mkdir([$this->tracksDirectory, $this->coversDirectory]);
+    }
+
+    public function handleUpload(Track $track, UploadedFile $audioFile, bool $replaceExisting = false): void
+    {
+        $safeName = $this->slugger->slug(pathinfo($audioFile->getClientOriginalName() ?: 'track', PATHINFO_FILENAME));
+        $extension = $audioFile->guessExtension() ?: $audioFile->getClientOriginalExtension() ?: 'mp3';
+        $fileName = sprintf('%s-%s.%s', $safeName, uniqid('', true), $extension);
+
+        $audioFile->move($this->tracksDirectory, $fileName);
+
+        if ($replaceExisting) {
+            $this->removeFile($track->getFilePath());
+        }
+
+        $absolutePath = $this->tracksDirectory.'/'.$fileName;
+        $track->setFilePath($this->relativeFromPublic($absolutePath));
+
+        $metadata = $this->metadataReader->extract($absolutePath);
+        $this->applyMetadata($track, $metadata);
+    }
+
+    public function ensureDefaults(Track $track, ?string $originalName = null): void
+    {
+        if (!$track->getTitle()) {
+            $track->setTitle($this->humanizeName($originalName ?? $track->getFilePath()) ?? self::UNKNOWN_TITLE);
+        }
+
+        if (!$track->getArtist()) {
+            $track->setArtist(self::UNKNOWN_ARTIST);
+        }
+
+        if (!$track->getAlbum()) {
+            $track->setAlbum(self::UNKNOWN_ALBUM);
+        }
+    }
+
+    public function removeMedia(Track $track): void
+    {
+        $this->removeFile($track->getFilePath());
+        $this->removeFile($track->getCoverImage());
+    }
+
+    private function applyMetadata(Track $track, AudioMetadata $metadata): void
+    {
+        if ($metadata->getTitle() && !$track->getTitle()) {
+            $track->setTitle($metadata->getTitle());
+        }
+
+        if ($metadata->getArtist() && !$track->getArtist()) {
+            $track->setArtist($metadata->getArtist());
+        }
+
+        if ($metadata->getAlbum() && !$track->getAlbum()) {
+            $track->setAlbum($metadata->getAlbum());
+        }
+
+        if ($metadata->getGenre() && !$track->getGenre()) {
+            $track->setGenre($metadata->getGenre());
+        }
+
+        if ($metadata->getDuration()) {
+            $track->setDuration($metadata->getDuration());
+        }
+
+        if ($metadata->getCover()) {
+            $this->storeCover($track, $metadata->getCover());
+        }
+
+        $this->ensureDefaults($track);
+    }
+
+    private function storeCover(Track $track, AudioCover $cover): void
+    {
+        $extension = $this->extensionFromMime($cover->getMimeType());
+        $base = $this->slugger->slug($track->getTitle() ?: 'cover');
+        $fileName = sprintf('%s-%s.%s', $base, uniqid('', true), $extension);
+        $absolutePath = $this->coversDirectory.'/'.$fileName;
+
+        if ($cover->getBinaryData() === '') {
+            return;
+        }
+
+        $this->filesystem->dumpFile($absolutePath, $cover->getBinaryData());
+
+        if ($track->getCoverImage()) {
+            $this->removeFile($track->getCoverImage());
+        }
+
+        $track->setCoverImage($this->relativeFromPublic($absolutePath));
+    }
+
+    private function extensionFromMime(string $mimeType): string
+    {
+        return match ($mimeType) {
+            'image/png' => 'png',
+            'image/webp' => 'webp',
+            'image/gif' => 'gif',
+            default => 'jpg',
+        };
+    }
+
+    private function relativeFromPublic(string $absolutePath): string
+    {
+        $publicDir = rtrim($this->projectDirectory.'/public', '/');
+        $relative = str_replace($publicDir, '', $absolutePath);
+
+        return ltrim($relative, '/');
+    }
+
+    private function removeFile(?string $relativePath): void
+    {
+        if (!$relativePath) {
+            return;
+        }
+
+        $absolute = $this->projectDirectory.'/public/'.$relativePath;
+        if ($this->filesystem->exists($absolute)) {
+            $this->filesystem->remove($absolute);
+        }
+    }
+
+    private function humanizeName(?string $name): ?string
+    {
+        if ($name === null) {
+            return null;
+        }
+
+        $base = pathinfo($name, PATHINFO_FILENAME);
+        if (!$base) {
+            return null;
+        }
+
+        $clean = preg_replace('/[_\-]+/', ' ', $base);
+        $clean = preg_replace('/\s+/', ' ', $clean ?? '');
+        $clean = trim((string) $clean);
+
+        if ($clean === '') {
+            return null;
+        }
+
+        return function_exists('mb_convert_case')
+            ? mb_convert_case($clean, MB_CASE_TITLE, 'UTF-8')
+            : ucwords(strtolower($clean));
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,19 +1,36 @@
 <!DOCTYPE html>
-<html>
+<html lang="ru">
     <head>
         <meta charset="UTF-8">
-        <title>{% block title %}Welcome!{% endblock %}</title>
-        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text></svg>">
-        {# Run `composer require symfony/webpack-encore-bundle` to start using Symfony UX #}
-        {% block stylesheets %}
-            {{ encore_entry_link_tags('app') }}
-        {% endblock %}
-
-        {% block javascripts %}
-            {{ encore_entry_script_tags('app') }}
-        {% endblock %}
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>{% block title %}MyPlayer{% endblock %}</title>
+        <link rel="icon" href="{{ asset('favicon.ico') }}">
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+        <link rel="stylesheet" href="{{ asset('app.css') }}">
+        {% block stylesheets %}{% endblock %}
     </head>
-    <body>
-        {% block body %}{% endblock %}
+    <body class="bg-body-tertiary">
+        <div class="position-fixed top-0 start-50 translate-middle-x mt-3" style="z-index: 1080; width: min(90%, 420px);">
+            {% for label, messages in app.flashes %}
+                {% for message in messages %}
+                    <div class="alert alert-{{ label }} alert-dismissible fade show shadow" role="alert">
+                        {{ message }}
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                    </div>
+                {% endfor %}
+            {% endfor %}
+        </div>
+        <div class="min-vh-100 d-flex flex-column">
+            <main class="flex-grow-1">
+                {% block body %}{% endblock %}
+            </main>
+        </div>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+        <script src="{{ asset('app.js') }}" defer></script>
+        {% block javascripts %}{% endblock %}
     </body>
 </html>

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -1,0 +1,151 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Музыкальный плеер{% endblock %}
+
+{% block body %}
+    {% set trackPayload = [] %}
+    {% for track in tracks %}
+        {% set trackPayload = trackPayload|merge([{
+            'id': track.id,
+            'title': track.title ?? defaults.title,
+            'artist': track.artist ?? defaults.artist,
+            'album': track.album ?? defaults.album,
+            'genre': track.genre,
+            'duration': track.duration,
+            'duration_formatted': track.formattedDuration,
+            'audioUrl': asset(track.filePath),
+            'coverUrl': track.coverImage ? asset(track.coverImage) : asset('images/default-cover.svg')
+        }]) %}
+    {% endfor %}
+
+    <div class="player-app py-4" data-player-root data-tracks="{{ trackPayload|json_encode|e('html_attr') }}" data-default-cover="{{ asset('images/default-cover.svg') }}">
+        <div class="container-fluid">
+            <div class="row g-4">
+                <div class="col-lg-3">
+                    <section class="glass-panel p-4 h-100 filters">
+                        <div class="mb-5">
+                            <h2 class="section-title mb-3">Исполнители</h2>
+                            <div class="list-group list-group-flush">
+                                <button type="button" class="list-group-item list-group-item-action active d-flex justify-content-between align-items-center" data-filter-group="artist" data-filter-value="">
+                                    <span>Все исполнители</span>
+                                    <span class="badge rounded-pill">{{ tracks|length }}</span>
+                                </button>
+                                {% for artist, count in artistCounts %}
+                                    <button type="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" data-filter-group="artist" data-filter-value="{{ artist|e('html_attr') }}">
+                                        <span>{{ artist }}</span>
+                                        <span class="badge rounded-pill">{{ count }}</span>
+                                    </button>
+                                {% endfor %}
+                            </div>
+                        </div>
+                        <div>
+                            <h2 class="section-title mb-3">Альбомы</h2>
+                            <div class="list-group list-group-flush">
+                                <button type="button" class="list-group-item list-group-item-action active d-flex justify-content-between align-items-center" data-filter-group="album" data-filter-value="">
+                                    <span>Все альбомы</span>
+                                    <span class="badge rounded-pill">{{ tracks|length }}</span>
+                                </button>
+                                {% for album, count in albumCounts %}
+                                    <button type="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" data-filter-group="album" data-filter-value="{{ album|e('html_attr') }}">
+                                        <span>{{ album }}</span>
+                                        <span class="badge rounded-pill">{{ count }}</span>
+                                    </button>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    </section>
+                </div>
+                <div class="col-lg-9">
+                    <section class="glass-panel p-4 h-100 d-flex flex-column gap-4">
+                        <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+                            <div>
+                                <h1 class="h3 mb-1">Моя музыка</h1>
+                                <p class="text-muted mb-0">Выберите трек, чтобы начать воспроизведение.</p>
+                            </div>
+                            <a href="{{ path('app_track_new') }}" class="btn btn-light btn-lg d-flex align-items-center gap-2 shadow-sm">
+                                <i class="bi bi-upload"></i>
+                                <span>Добавить трек</span>
+                            </a>
+                        </div>
+
+                        {% if tracks is not empty %}
+                            <div class="track-collection d-flex flex-column gap-2" data-track-list>
+                                {% for track in tracks %}
+                                    {% set title = track.title ?? defaults.title %}
+                                    {% set artist = track.artist ?? defaults.artist %}
+                                    {% set album = track.album ?? defaults.album %}
+                                    {% set cover = track.coverImage ? asset(track.coverImage) : asset('images/default-cover.svg') %}
+                                    <button type="button" class="track-item d-flex align-items-center gap-3" data-track-index="{{ loop.index0 }}" data-artist="{{ artist|e('html_attr') }}" data-album="{{ album|e('html_attr') }}">
+                                        <div class="d-flex align-items-center gap-3 flex-grow-1">
+                                            <div class="track-cover">
+                                                <img src="{{ cover }}" alt="Обложка {{ title }}">
+                                            </div>
+                                            <div class="flex-grow-1">
+                                                <div class="track-title">{{ title }}</div>
+                                                <div class="track-meta">{{ artist }} • {{ album }}</div>
+                                            </div>
+                                        </div>
+                                        <div class="track-duration" data-duration>{{ track.formattedDuration ?? '--:--' }}</div>
+                                    </button>
+                                {% endfor %}
+                            </div>
+                        {% else %}
+                            <div class="empty-state">
+                                <div class="icon"><i class="bi bi-music-note-beamed"></i></div>
+                                <h2 class="h4 text-white">Добавьте свой первый трек</h2>
+                                <p class="mb-4">Импортируйте любимые композиции, чтобы начать прослушивание.</p>
+                                <a href="{{ path('app_track_new') }}" class="btn btn-outline-light btn-lg">Загрузить трек</a>
+                            </div>
+                        {% endif %}
+                    </section>
+                </div>
+            </div>
+        </div>
+
+        <div class="player-bar mt-4" data-player-bar>
+            <div class="container-fluid">
+                <div class="row align-items-center g-3">
+                    <div class="col-lg-4 d-flex align-items-center gap-3">
+                        <div class="player-cover-sm">
+                            <img src="{{ asset('images/default-cover.svg') }}" alt="Текущая обложка" data-current-cover>
+                        </div>
+                        <div>
+                            <div class="fw-semibold" data-current-title>Выберите трек</div>
+                            <div class="text-muted" data-current-meta></div>
+                        </div>
+                    </div>
+                    <div class="col-lg-4">
+                        <div class="d-flex flex-column align-items-center gap-3">
+                            <div class="d-flex align-items-center gap-3">
+                                <button type="button" class="btn-circle" data-control="prev" aria-label="Предыдущий трек">
+                                    <i class="bi bi-skip-backward-fill"></i>
+                                </button>
+                                <button type="button" class="btn-circle primary" data-control="play" aria-label="Воспроизвести">
+                                    <i class="bi bi-play-fill"></i>
+                                </button>
+                                <button type="button" class="btn-circle" data-control="next" aria-label="Следующий трек">
+                                    <i class="bi bi-skip-forward-fill"></i>
+                                </button>
+                            </div>
+                            <div class="progress-area d-flex align-items-center gap-2">
+                                <span class="small text-muted" data-current-time>0:00</span>
+                                <input type="range" class="form-range flex-grow-1" min="0" max="100" step="1" value="0" data-progress>
+                                <span class="small text-muted" data-duration>0:00</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-lg-4 d-flex align-items-center justify-content-lg-end gap-3">
+                        <button type="button" class="btn-circle" data-control="shuffle" aria-label="Перемешать" aria-pressed="false">
+                            <i class="bi bi-shuffle"></i>
+                        </button>
+                        <div class="volume-control d-flex align-items-center gap-2">
+                            <i class="bi bi-volume-up-fill"></i>
+                            <input type="range" class="form-range" min="0" max="100" step="1" value="80" data-volume>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <audio data-audio preload="metadata" class="d-none"></audio>
+    </div>
+{% endblock %}

--- a/templates/track/_delete_form.html.twig
+++ b/templates/track/_delete_form.html.twig
@@ -1,4 +1,7 @@
-<form method="post" action="{{ path('app_track_delete', {'id': track.id}) }}" onsubmit="return confirm('Are you sure you want to delete this item?');">
+<form method="post" action="{{ path('app_track_delete', {'id': track.id}) }}" class="d-inline" onsubmit="return confirm('Удалить трек «{{ trackName|default(track.title ?? 'этот трек') }}»?');">
     <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ track.id) }}">
-    <button class="btn">Delete</button>
+    <button class="{{ btn_class|default('btn btn-outline-danger btn-sm') }}">
+        <i class="bi bi-trash"></i>
+        <span class="d-none d-sm-inline">Удалить</span>
+    </button>
 </form>

--- a/templates/track/_form.html.twig
+++ b/templates/track/_form.html.twig
@@ -1,4 +1,27 @@
-{{ form_start(form) }}
-    {{ form_widget(form) }}
-    <button class="btn">{{ button_label|default('Save') }}</button>
+{{ form_start(form, {'attr': {'class': 'row g-4'}}) }}
+    <div class="col-12">
+        {{ form_label(form.audioFile, null, {'label_attr': {'class': 'form-label text-uppercase small text-muted fw-semibold'}}) }}
+        {{ form_widget(form.audioFile, {'attr': {'class': 'form-control form-control-lg'}}) }}
+        <div class="form-text text-muted">{{ form_help(form.audioFile) }}</div>
+        {{ form_errors(form.audioFile) }}
+    </div>
+    <div class="col-md-6">
+        {{ form_row(form.title, {'attr': {'class': 'form-control form-control-lg'}}) }}
+    </div>
+    <div class="col-md-6">
+        {{ form_row(form.artist, {'attr': {'class': 'form-control form-control-lg'}}) }}
+    </div>
+    <div class="col-md-6">
+        {{ form_row(form.album, {'attr': {'class': 'form-control form-control-lg'}}) }}
+    </div>
+    <div class="col-md-6">
+        {{ form_row(form.genre, {'attr': {'class': 'form-control form-control-lg'}}) }}
+    </div>
+    <div class="col-12 d-flex justify-content-end gap-2 pt-3">
+        <a href="{{ path('app_track_index') }}" class="btn btn-outline-light px-4">
+            <i class="bi bi-arrow-left"></i>
+            Назад
+        </a>
+        <button class="btn btn-primary btn-lg px-4">{{ button_label|default('Сохранить') }}</button>
+    </div>
 {{ form_end(form) }}

--- a/templates/track/edit.html.twig
+++ b/templates/track/edit.html.twig
@@ -1,13 +1,32 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Edit Track{% endblock %}
+{% block title %}Редактировать трек{% endblock %}
 
 {% block body %}
-    <h1>Edit Track</h1>
+    <div class="container py-5">
+        <div class="row justify-content-center">
+            <div class="col-lg-8">
+                <div class="glass-panel p-4 p-lg-5">
+                    <div class="d-flex justify-content-between align-items-start gap-3 mb-4">
+                        <div>
+                            <h1 class="h3 mb-2">Редактирование трека</h1>
+                            <p class="text-muted mb-0">При загрузке нового файла метаданные обновятся автоматически.</p>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <a href="{{ path('app_track_show', {'id': track.id}) }}" class="btn btn-outline-light">
+                                <i class="bi bi-eye"></i>
+                                Просмотр
+                            </a>
+                            <a href="{{ path('app_track_index') }}" class="btn btn-outline-light">
+                                <i class="bi bi-arrow-left"></i>
+                                К списку
+                            </a>
+                        </div>
+                    </div>
 
-    {{ include('track/_form.html.twig', {'button_label': 'Update'}) }}
-
-    <a href="{{ path('app_track_index') }}">back to list</a>
-
-    {{ include('track/_delete_form.html.twig') }}
+                    {{ include('track/_form.html.twig', {'form': form, 'button_label': 'Обновить трек'}) }}
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}

--- a/templates/track/index.html.twig
+++ b/templates/track/index.html.twig
@@ -1,47 +1,70 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Track index{% endblock %}
+{% block title %}Коллекция треков{% endblock %}
 
 {% block body %}
-    <h1>Track index</h1>
+    <div class="container py-5">
+        <div class="d-flex flex-wrap justify-content-between align-items-center mb-4 gap-3">
+            <div>
+                <h1 class="h3 mb-1">Коллекция треков</h1>
+                <p class="text-muted mb-0">Управляйте аудиотекой и обновляйте метаданные.</p>
+            </div>
+            <a href="{{ path('app_track_new') }}" class="btn btn-primary btn-lg d-flex align-items-center gap-2">
+                <i class="bi bi-upload"></i>
+                <span>Добавить трек</span>
+            </a>
+        </div>
 
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Id</th>
-                <th>Title</th>
-                <th>Artist</th>
-                <th>Duration</th>
-                <th>FilePath</th>
-                <th>Album</th>
-                <th>Genre</th>
-                <th>CoverImage</th>
-                <th>actions</th>
-            </tr>
-        </thead>
-        <tbody>
-        {% for track in tracks %}
-            <tr>
-                <td>{{ track.id }}</td>
-                <td>{{ track.title }}</td>
-                <td>{{ track.artist }}</td>
-                <td>{{ track.duration }}</td>
-                <td>{{ track.filePath }}</td>
-                <td>{{ track.album }}</td>
-                <td>{{ track.genre }}</td>
-                <td>{{ track.coverImage }}</td>
-                <td>
-                    <a href="{{ path('app_track_show', {'id': track.id}) }}">show</a>
-                    <a href="{{ path('app_track_edit', {'id': track.id}) }}">edit</a>
-                </td>
-            </tr>
-        {% else %}
-            <tr>
-                <td colspan="9">no records found</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
-
-    <a href="{{ path('app_track_new') }}">Create new</a>
+        <div class="glass-panel p-4">
+            {% if tracks is not empty %}
+                <div class="table-responsive">
+                    <table class="table table-hover align-middle mb-0 text-white">
+                        <thead class="table-dark">
+                            <tr>
+                                <th scope="col">Трек</th>
+                                <th scope="col">Исполнитель</th>
+                                <th scope="col">Альбом</th>
+                                <th scope="col">Жанр</th>
+                                <th scope="col">Длительность</th>
+                                <th scope="col" class="text-end">Действия</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for track in tracks %}
+                                {% set title = track.title ?? defaults.title %}
+                                {% set artist = track.artist ?? defaults.artist %}
+                                {% set album = track.album ?? defaults.album %}
+                                <tr>
+                                    <td>
+                                        <div class="fw-semibold">{{ title }}</div>
+                                        <div class="text-muted small">{{ track.filePath }}</div>
+                                    </td>
+                                    <td>{{ artist }}</td>
+                                    <td>{{ album }}</td>
+                                    <td>{{ track.genre ?? '—' }}</td>
+                                    <td>{{ track.formattedDuration ?? '—' }}</td>
+                                    <td class="text-end">
+                                        <div class="d-inline-flex gap-2">
+                                            <a href="{{ path('app_track_show', {'id': track.id}) }}" class="btn btn-outline-light btn-sm" title="Просмотр">
+                                                <i class="bi bi-eye"></i>
+                                            </a>
+                                            <a href="{{ path('app_track_edit', {'id': track.id}) }}" class="btn btn-outline-light btn-sm" title="Редактировать">
+                                                <i class="bi bi-pencil"></i>
+                                            </a>
+                                            {{ include('track/_delete_form.html.twig', { 'track': track, 'trackName': title }) }}
+                                        </div>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% else %}
+                <div class="py-5 text-center text-muted">
+                    <p class="mb-3">Треки пока не добавлены.</p>
+                    <a href="{{ path('app_track_new') }}" class="btn btn-outline-light">Добавить первый трек</a>
+                </div>
+            {% endif %}
+        </div>
+    </div>
 {% endblock %}

--- a/templates/track/new.html.twig
+++ b/templates/track/new.html.twig
@@ -1,11 +1,26 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}New Track{% endblock %}
+{% block title %}Добавить трек{% endblock %}
 
 {% block body %}
-    <h1>Create new Track</h1>
+    <div class="container py-5">
+        <div class="row justify-content-center">
+            <div class="col-lg-8">
+                <div class="glass-panel p-4 p-lg-5">
+                    <div class="d-flex justify-content-between align-items-start gap-3 mb-4">
+                        <div>
+                            <h1 class="h3 mb-2">Добавление трека</h1>
+                            <p class="text-muted mb-0">Загрузите аудиофайл, метаданные подтянутся автоматически.</p>
+                        </div>
+                        <a href="{{ path('app_track_index') }}" class="btn btn-outline-light">
+                            <i class="bi bi-arrow-left"></i>
+                            К списку
+                        </a>
+                    </div>
 
-    {{ include('track/_form.html.twig') }}
-
-    <a href="{{ path('app_track_index') }}">back to list</a>
+                    {{ include('track/_form.html.twig', {'form': form, 'button_label': 'Сохранить трек'}) }}
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}

--- a/templates/track/show.html.twig
+++ b/templates/track/show.html.twig
@@ -1,50 +1,63 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Track{% endblock %}
+{% block title %}{{ track.title ?? defaults.title }}{% endblock %}
 
 {% block body %}
-    <h1>Track</h1>
+    <div class="container py-5">
+        <div class="row justify-content-center">
+            <div class="col-lg-10">
+                <div class="glass-panel p-4 p-lg-5">
+                    <div class="d-flex flex-wrap justify-content-between align-items-start gap-3 mb-4">
+                        <div>
+                            <h1 class="h3 mb-2">{{ track.title ?? defaults.title }}</h1>
+                            <p class="text-muted mb-0">{{ (track.artist ?? defaults.artist) ~ ' • ' ~ (track.album ?? defaults.album) }}</p>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <a href="{{ path('app_track_edit', {'id': track.id}) }}" class="btn btn-outline-light">
+                                <i class="bi bi-pencil"></i>
+                                Редактировать
+                            </a>
+                            <a href="{{ path('app_track_index') }}" class="btn btn-outline-light">
+                                <i class="bi bi-arrow-left"></i>
+                                К списку
+                            </a>
+                        </div>
+                    </div>
 
-    <table class="table">
-        <tbody>
-            <tr>
-                <th>Id</th>
-                <td>{{ track.id }}</td>
-            </tr>
-            <tr>
-                <th>Title</th>
-                <td>{{ track.title }}</td>
-            </tr>
-            <tr>
-                <th>Artist</th>
-                <td>{{ track.artist }}</td>
-            </tr>
-            <tr>
-                <th>Duration</th>
-                <td>{{ track.duration }}</td>
-            </tr>
-            <tr>
-                <th>FilePath</th>
-                <td>{{ track.filePath }}</td>
-            </tr>
-            <tr>
-                <th>Album</th>
-                <td>{{ track.album }}</td>
-            </tr>
-            <tr>
-                <th>Genre</th>
-                <td>{{ track.genre }}</td>
-            </tr>
-            <tr>
-                <th>CoverImage</th>
-                <td>{{ track.coverImage }}</td>
-            </tr>
-        </tbody>
-    </table>
+                    <div class="row g-4 align-items-start">
+                        <div class="col-md-4">
+                            <div class="player-cover-sm w-100" style="height: auto; aspect-ratio: 1;">
+                                <img src="{{ track.coverImage ? asset(track.coverImage) : asset('images/default-cover.svg') }}" alt="Обложка">
+                            </div>
+                        </div>
+                        <div class="col-md-8">
+                            <dl class="row gy-3 mb-0">
+                                <dt class="col-sm-4 text-muted">Исполнитель</dt>
+                                <dd class="col-sm-8">{{ track.artist ?? defaults.artist }}</dd>
+                                <dt class="col-sm-4 text-muted">Альбом</dt>
+                                <dd class="col-sm-8">{{ track.album ?? defaults.album }}</dd>
+                                <dt class="col-sm-4 text-muted">Жанр</dt>
+                                <dd class="col-sm-8">{{ track.genre ?? '—' }}</dd>
+                                <dt class="col-sm-4 text-muted">Длительность</dt>
+                                <dd class="col-sm-8">{{ track.formattedDuration ?? '—' }}</dd>
+                                <dt class="col-sm-4 text-muted">Файл</dt>
+                                <dd class="col-sm-8">
+                                    <a href="{{ asset(track.filePath) }}" class="link-light" target="_blank">{{ track.filePath }}</a>
+                                </dd>
+                            </dl>
+                            <div class="mt-4">
+                                <audio class="w-100" controls preload="metadata" src="{{ asset(track.filePath) }}">
+                                    Ваш браузер не поддерживает воспроизведение аудио.
+                                </audio>
+                            </div>
+                        </div>
+                    </div>
 
-    <a href="{{ path('app_track_index') }}">back to list</a>
-
-    <a href="{{ path('app_track_edit', {'id': track.id}) }}">edit</a>
-
-    {{ include('track/_delete_form.html.twig') }}
+                    <div class="mt-4 d-flex justify-content-end">
+                        {{ include('track/_delete_form.html.twig', { 'track': track, 'trackName': track.title ?? defaults.title, 'btn_class': 'btn btn-outline-danger' }) }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- refresh the base layout with Bootstrap 5 styling and add a rich home player UI with track filters, playback controls, and modern theming
- introduce services for parsing audio metadata during uploads, storing covers, and providing sensible defaults for titles, artists, and albums
- modernize track CRUD templates, configure Twig form themes, and add static assets (CSS/JS/images) to support the new experience

## Testing
- `composer validate`
- `php -l src/Service/TrackManager.php`
- `php -l src/Service/Audio/AudioMetadataReader.php`
- `php -l src/Controller/DefaultController.php`
- `php -l src/Controller/TrackController.php`
- `composer install` *(fails: GitHub OAuth token required in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8cd931908323b102897b589fa2ad