### PR TITLE
Add playlist management

### DIFF
--- a/migrations/Version20250915140000.php
+++ b/migrations/Version20250915140000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250915140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Создание таблицы плейлистов';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE playlist (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE playlist');
+    }
+}

--- a/src/Controller/PlaylistController.php
+++ b/src/Controller/PlaylistController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Playlist;
+use App\Form\PlaylistType;
+use App\Repository\PlaylistRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/playlist')]
+class PlaylistController extends AbstractController
+{
+    #[Route('/', name: 'app_playlist_index', methods: ['GET'])]
+    public function index(PlaylistRepository $playlistRepository): Response
+    {
+        $playlists = $playlistRepository->findBy([], ['id' => 'DESC']);
+
+        return $this->render('playlist/index.html.twig', [
+            'playlists' => $playlists,
+        ]);
+    }
+
+    #[Route('/new', name: 'app_playlist_new', methods: ['GET', 'POST'])]
+    public function new(Request $request, EntityManagerInterface $entityManager): Response
+    {
+        $playlist = new Playlist();
+        $form = $this->createForm(PlaylistType::class, $playlist);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $entityManager->persist($playlist);
+            $entityManager->flush();
+
+            $this->addFlash('success', 'Плейлист создан.');
+
+            return $this->redirectToRoute('app_playlist_index', [], Response::HTTP_SEE_OTHER);
+        }
+
+        return $this->renderForm('playlist/new.html.twig', [
+            'playlist' => $playlist,
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/{id}', name: 'app_playlist_delete', methods: ['POST'])]
+    public function delete(Request $request, Playlist $playlist, EntityManagerInterface $entityManager): Response
+    {
+        if ($this->isCsrfTokenValid('delete'.$playlist->getId(), (string) $request->request->get('_token'))) {
+            $entityManager->remove($playlist);
+            $entityManager->flush();
+
+            $this->addFlash('success', 'Плейлист удалён.');
+        }
+
+        return $this->redirectToRoute('app_playlist_index', [], Response::HTTP_SEE_OTHER);
+    }
+}

--- a/src/Entity/Playlist.php
+++ b/src/Entity/Playlist.php
@@ -2,9 +2,10 @@
 
 namespace App\Entity;
 
+use App\Repository\PlaylistRepository;
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: PlaylistRepository::class)]
 class Playlist
 {
     #[ORM\Id]
@@ -12,8 +13,23 @@ class Playlist
     #[ORM\Column]
     private ?int $id = null;
 
+    #[ORM\Column(length: 255)]
+    private ?string $name = null;
+
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
     }
 }

--- a/src/Form/PlaylistType.php
+++ b/src/Form/PlaylistType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Playlist;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class PlaylistType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('name', TextType::class, [
+            'label' => 'Название',
+            'attr' => ['placeholder' => 'Название плейлиста'],
+            'constraints' => [
+                new NotBlank([
+                    'message' => 'Укажите название плейлиста.',
+                ]),
+            ],
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Playlist::class,
+        ]);
+    }
+}

--- a/src/Repository/PlaylistRepository.php
+++ b/src/Repository/PlaylistRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Playlist;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class PlaylistRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Playlist::class);
+    }
+}

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -62,10 +62,16 @@
                                 <h1 class="h3 mb-1">Моя музыка</h1>
                                 <p class="text-muted mb-0">Выберите трек, чтобы начать воспроизведение.</p>
                             </div>
-                            <a href="{{ path('app_track_new') }}" class="btn btn-light btn-lg d-flex align-items-center gap-2 shadow-sm">
-                                <i class="bi bi-upload"></i>
-                                <span>Добавить трек</span>
-                            </a>
+                            <div class="d-flex flex-wrap gap-2">
+                                <a href="{{ path('app_track_new') }}" class="btn btn-light btn-lg d-flex align-items-center gap-2 shadow-sm">
+                                    <i class="bi bi-upload"></i>
+                                    <span>Добавить трек</span>
+                                </a>
+                                <a href="{{ path('app_playlist_index') }}" class="btn btn-outline-light btn-lg d-flex align-items-center gap-2 shadow-sm">
+                                    <i class="bi bi-music-note-list"></i>
+                                    <span>Плейлисты</span>
+                                </a>
+                            </div>
                         </div>
 
                         {% if tracks is not empty %}

--- a/templates/playlist/_delete_form.html.twig
+++ b/templates/playlist/_delete_form.html.twig
@@ -1,0 +1,7 @@
+<form method="post" action="{{ path('app_playlist_delete', {'id': playlist.id}) }}" class="d-inline" onsubmit="return confirm('Удалить плейлист «{{ playlistName|default(playlist.name ?? 'этот плейлист') }}»?');">
+    <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ playlist.id) }}">
+    <button class="{{ btn_class|default('btn btn-outline-danger btn-sm') }}">
+        <i class="bi bi-trash"></i>
+        <span class="d-none d-sm-inline">Удалить</span>
+    </button>
+</form>

--- a/templates/playlist/_form.html.twig
+++ b/templates/playlist/_form.html.twig
@@ -1,0 +1,12 @@
+{{ form_start(form, {'attr': {'class': 'row g-4'}}) }}
+    <div class="col-12">
+        {{ form_row(form.name, {'attr': {'class': 'form-control form-control-lg'}}) }}
+    </div>
+    <div class="col-12 d-flex justify-content-end gap-2 pt-3">
+        <a href="{{ path('app_playlist_index') }}" class="btn btn-outline-light px-4">
+            <i class="bi bi-arrow-left"></i>
+            Назад
+        </a>
+        <button class="btn btn-primary btn-lg px-4">{{ button_label|default('Сохранить') }}</button>
+    </div>
+{{ form_end(form) }}

--- a/templates/playlist/index.html.twig
+++ b/templates/playlist/index.html.twig
@@ -1,0 +1,53 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Плейлисты{% endblock %}
+
+{% block body %}
+    <div class="container py-5">
+        <div class="d-flex flex-wrap justify-content-between align-items-center mb-4 gap-3">
+            <div>
+                <h1 class="h3 mb-1">Плейлисты</h1>
+                <p class="text-muted mb-0">Создавайте подборки треков и управляйте ими.</p>
+            </div>
+            <a href="{{ path('app_playlist_new') }}" class="btn btn-primary btn-lg d-flex align-items-center gap-2">
+                <i class="bi bi-plus-lg"></i>
+                <span>Новый плейлист</span>
+            </a>
+        </div>
+
+        <div class="glass-panel p-4">
+            {% if playlists is not empty %}
+                <div class="table-responsive">
+                    <table class="table table-hover align-middle mb-0 text-white">
+                        <thead class="table-dark">
+                            <tr>
+                                <th scope="col">Название</th>
+                                <th scope="col" class="text-end">Действия</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for playlist in playlists %}
+                                <tr>
+                                    <td>
+                                        <div class="fw-semibold">{{ playlist.name }}</div>
+                                    </td>
+                                    <td class="text-end">
+                                        {{ include('playlist/_delete_form.html.twig', {
+                                            'playlist': playlist,
+                                            'playlistName': playlist.name
+                                        }) }}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% else %}
+                <div class="py-5 text-center text-muted">
+                    <p class="mb-3">Плейлисты пока не созданы.</p>
+                    <a href="{{ path('app_playlist_new') }}" class="btn btn-outline-light">Создать первый плейлист</a>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}

--- a/templates/playlist/new.html.twig
+++ b/templates/playlist/new.html.twig
@@ -1,0 +1,26 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Новый плейлист{% endblock %}
+
+{% block body %}
+    <div class="container py-5">
+        <div class="row justify-content-center">
+            <div class="col-lg-6 col-xl-5">
+                <div class="glass-panel p-4 p-lg-5">
+                    <div class="d-flex justify-content-between align-items-start gap-3 mb-4">
+                        <div>
+                            <h1 class="h3 mb-2">Создание плейлиста</h1>
+                            <p class="text-muted mb-0">Дайте плейлисту название, чтобы начать наполнять его треками.</p>
+                        </div>
+                        <a href="{{ path('app_playlist_index') }}" class="btn btn-outline-light">
+                            <i class="bi bi-arrow-left"></i>
+                            К списку
+                        </a>
+                    </div>
+
+                    {{ include('playlist/_form.html.twig', {'form': form, 'button_label': 'Сохранить плейлист'}) }}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a repository-backed Playlist entity with a required name field and schema migration
- implement playlist CRUD UI (controller, form, Twig templates) and link it from the homepage

## Testing
- `composer install` *(fails: GitHub API 403 required credentials while downloading symfony/flex)*

------
https://chatgpt.com/codex/tasks/task_e_68cb11947fd883239459387cbe60d56f