### PR TITLE
Add audio visualizer feature with UI and persistence

### DIFF
--- a/.env
+++ b/.env
@@ -41,3 +41,7 @@ MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 ###> symfony/mailer ###
 MAILER_DSN=null://null
 ###< symfony/mailer ###
+
+###> app/visualizer ###
+FEATURE_VISUALIZER=1
+###< app/visualizer ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,6 +6,13 @@
 parameters:
     app.upload_dir.tracks: '%kernel.project_dir%/public/uploads/tracks'
     app.upload_dir.covers: '%kernel.project_dir%/public/uploads/covers'
+    features.visualizer: '%env(bool:FEATURE_VISUALIZER)%'
+    visualizer.defaults:
+        enabled: true
+        mode: 'bars'
+        sensitivity: 0.85
+        smoothing: 0.6
+        theme: 'neon'
 
 services:
     # default configuration for services in *this* file

--- a/public/app.css
+++ b/public/app.css
@@ -226,6 +226,218 @@ a:hover {
     margin-bottom: 1rem;
 }
 
+.visualizer-panel {
+    --visualizer-surface: linear-gradient(135deg, rgba(15, 23, 42, 0.82) 0%, rgba(30, 41, 59, 0.9) 100%);
+    --visualizer-border: rgba(148, 163, 184, 0.28);
+    --visualizer-text: var(--player-text-primary);
+    --visualizer-muted: var(--player-text-muted);
+    --visualizer-accent: #38bdf8;
+    --visualizer-chip: rgba(148, 163, 184, 0.2);
+    --visualizer-glow: rgba(56, 189, 248, 0.3);
+    --visualizer-state-running: rgba(56, 189, 248, 0.2);
+    --visualizer-state-border: rgba(56, 189, 248, 0.35);
+    padding: 1.75rem;
+    border-radius: 24px;
+    background: var(--visualizer-surface);
+    border: 1px solid var(--visualizer-border);
+    backdrop-filter: blur(18px);
+    color: var(--visualizer-text);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.45);
+}
+
+.visualizer-panel[data-visualizer-theme="aurora"] {
+    --visualizer-surface: linear-gradient(135deg, rgba(7, 30, 61, 0.88) 0%, rgba(12, 63, 83, 0.95) 100%);
+    --visualizer-border: rgba(45, 212, 191, 0.35);
+    --visualizer-accent: #34d399;
+    --visualizer-chip: rgba(52, 211, 153, 0.16);
+    --visualizer-glow: rgba(45, 212, 191, 0.28);
+    --visualizer-state-running: rgba(34, 211, 238, 0.2);
+    --visualizer-state-border: rgba(34, 211, 238, 0.32);
+}
+
+.visualizer-panel[data-visualizer-theme="sunset"] {
+    --visualizer-surface: linear-gradient(140deg, rgba(59, 16, 38, 0.9) 0%, rgba(109, 26, 35, 0.95) 100%);
+    --visualizer-border: rgba(249, 115, 22, 0.32);
+    --visualizer-accent: #f97316;
+    --visualizer-chip: rgba(248, 113, 113, 0.18);
+    --visualizer-glow: rgba(249, 115, 22, 0.28);
+    --visualizer-state-running: rgba(249, 115, 22, 0.22);
+    --visualizer-state-border: rgba(249, 115, 22, 0.35);
+}
+
+.visualizer-panel[data-visualizer-theme="light"] {
+    --visualizer-surface: linear-gradient(135deg, rgba(248, 250, 252, 0.94) 0%, rgba(229, 234, 245, 0.95) 100%);
+    --visualizer-border: rgba(148, 163, 184, 0.35);
+    --visualizer-text: #0f172a;
+    --visualizer-muted: rgba(71, 85, 105, 0.7);
+    --visualizer-accent: #6366f1;
+    --visualizer-chip: rgba(148, 163, 184, 0.25);
+    --visualizer-glow: rgba(99, 102, 241, 0.25);
+    --visualizer-state-running: rgba(99, 102, 241, 0.22);
+    --visualizer-state-border: rgba(99, 102, 241, 0.32);
+    color: var(--visualizer-text);
+    box-shadow: 0 16px 40px rgba(15, 23, 42, 0.18);
+}
+
+.visualizer-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.25rem;
+}
+
+.visualizer-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 16px;
+    background: var(--visualizer-chip);
+    color: var(--visualizer-accent);
+    font-size: 1.35rem;
+    box-shadow: 0 10px 30px var(--visualizer-glow);
+}
+
+.visualizer-state {
+    background: rgba(148, 163, 184, 0.18);
+    color: var(--visualizer-text);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    padding: 0.5rem 0.9rem;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.visualizer-state[data-state="running"] {
+    background: var(--visualizer-state-running);
+    border-color: var(--visualizer-state-border);
+}
+
+.visualizer-state[data-state="disabled"] {
+    opacity: 0.65;
+}
+
+.visualizer-modes {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.visualizer-modes .btn {
+    border-radius: 999px;
+    border: 1px solid transparent;
+    background: var(--visualizer-chip);
+    color: var(--visualizer-text);
+    padding: 0.45rem 1.2rem;
+    font-weight: 500;
+    transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.visualizer-modes .btn:hover,
+.visualizer-modes .btn:focus-visible {
+    background: rgba(255, 255, 255, 0.12);
+    color: var(--visualizer-text);
+}
+
+.visualizer-modes .btn.active {
+    background: var(--visualizer-accent);
+    color: #fff;
+    box-shadow: 0 12px 32px var(--visualizer-glow);
+    transform: translateY(-1px);
+}
+
+.visualizer-canvas {
+    position: relative;
+    border-radius: 20px;
+    overflow: hidden;
+    min-height: 240px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(15, 23, 42, 0.5);
+}
+
+.visualizer-panel[data-visualizer-theme="light"] .visualizer-canvas {
+    background: rgba(226, 232, 240, 0.65);
+    border-color: rgba(148, 163, 184, 0.4);
+}
+
+.visualizer-canvas canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.visualizer-placeholder {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    text-align: center;
+    color: var(--visualizer-muted);
+    pointer-events: none;
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.35), rgba(30, 41, 59, 0.4));
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.visualizer-panel[data-visualizer-theme="light"] .visualizer-placeholder {
+    background: linear-gradient(135deg, rgba(248, 250, 252, 0.7), rgba(226, 232, 240, 0.75));
+}
+
+.visualizer-placeholder[data-state="hidden"] {
+    opacity: 0;
+    visibility: hidden;
+}
+
+.visualizer-placeholder-content i {
+    font-size: 2.5rem;
+    color: var(--visualizer-accent);
+    display: block;
+}
+
+.visualizer-settings .form-label {
+    color: var(--visualizer-muted);
+    letter-spacing: 0.08em;
+}
+
+.visualizer-settings .form-range {
+    accent-color: var(--visualizer-accent);
+}
+
+.visualizer-settings .form-select {
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    background: rgba(15, 23, 42, 0.45);
+    color: var(--visualizer-text);
+    padding: 0.65rem 1rem;
+}
+
+.visualizer-panel[data-visualizer-theme="light"] .form-select {
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(148, 163, 184, 0.35);
+    color: #0f172a;
+}
+
+.visualizer-settings .form-text {
+    color: var(--visualizer-muted);
+}
+
+.visualizer-panel .form-check-input {
+    width: 3rem;
+    height: 1.5rem;
+    cursor: pointer;
+    border-radius: 999px;
+}
+
+.visualizer-panel .form-check-input:checked {
+    background-color: var(--visualizer-accent);
+    border-color: var(--visualizer-accent);
+}
+
+.visualizer-panel .form-check-label {
+    color: var(--visualizer-muted);
+    font-weight: 500;
+}
+
 @media (max-width: 991.98px) {
     .track-collection {
         max-height: none;
@@ -235,6 +447,18 @@ a:hover {
         position: static;
         border-radius: 24px 24px 0 0;
         margin-top: 2rem;
+    }
+
+    .visualizer-panel {
+        padding: 1.5rem;
+    }
+
+    .visualizer-modes {
+        flex-wrap: wrap;
+    }
+
+    .visualizer-canvas {
+        min-height: 200px;
     }
 }
 
@@ -257,5 +481,23 @@ a:hover {
     .btn-circle.primary {
         width: 46px;
         height: 46px;
+    }
+
+    .visualizer-panel {
+        padding: 1.25rem;
+        gap: 1.25rem;
+    }
+
+    .visualizer-toolbar {
+        gap: 1rem;
+    }
+
+    .visualizer-icon {
+        width: 44px;
+        height: 44px;
+    }
+
+    .visualizer-canvas {
+        min-height: 180px;
     }
 }

--- a/public/app.js
+++ b/public/app.js
@@ -20,6 +20,16 @@
         return;
     }
 
+    const visualizerRoot = playerRoot.querySelector('[data-visualizer-root]');
+    const visualizer = visualizerRoot && window.MyPlayerVisualizer && typeof window.MyPlayerVisualizer.attachVisualizer === 'function'
+        ? window.MyPlayerVisualizer.attachVisualizer({
+            root: visualizerRoot,
+            audio,
+            window,
+            document,
+        })
+        : null;
+
     const defaultCover = playerRoot.dataset.defaultCover || '';
     const trackList = playerRoot.querySelector('[data-track-list]');
     const trackItems = trackList ? Array.from(trackList.querySelectorAll('[data-track-index]')) : [];

--- a/public/visualizer.js
+++ b/public/visualizer.js
@@ -1,0 +1,959 @@
+(function (global) {
+    'use strict';
+
+    const defaultWindow = typeof window !== 'undefined' && window.document ? window : (global && global.document ? global : undefined);
+
+    const fallbackRequestAnimationFrame = (callback) => setTimeout(() => callback(Date.now()), 16);
+    const fallbackCancelAnimationFrame = (handle) => clearTimeout(handle);
+
+    const SUPPORTED_MODES = ['bars', 'wave', 'rings', 'particles'];
+
+    const THEMES = {
+        neon: {
+            background: 'rgba(15, 23, 42, 0.65)',
+            gradient: ['#38bdf8', '#c084fc'],
+            accent: '#f472b6',
+            glow: 'rgba(56, 189, 248, 0.45)',
+            particle: '#38bdf8',
+        },
+        aurora: {
+            background: 'rgba(4, 30, 49, 0.7)',
+            gradient: ['#22d3ee', '#34d399'],
+            accent: '#fef3c7',
+            glow: 'rgba(52, 211, 153, 0.45)',
+            particle: '#34d399',
+        },
+        sunset: {
+            background: 'rgba(58, 12, 35, 0.72)',
+            gradient: ['#f97316', '#fb7185'],
+            accent: '#fde047',
+            glow: 'rgba(249, 115, 22, 0.45)',
+            particle: '#fb7185',
+        },
+        light: {
+            background: 'rgba(248, 250, 252, 0.92)',
+            gradient: ['#64748b', '#0ea5e9'],
+            accent: '#6366f1',
+            glow: 'rgba(148, 163, 184, 0.4)',
+            particle: '#475569',
+        },
+    };
+
+    const DEFAULT_SETTINGS = {
+        enabled: true,
+        mode: 'bars',
+        sensitivity: 0.85,
+        smoothing: 0.6,
+        theme: 'neon',
+    };
+
+    function clamp(value, min, max) {
+        if (!Number.isFinite(value)) {
+            return min;
+        }
+        return Math.min(max, Math.max(min, value));
+    }
+
+    function createDefaultAudioContextFactory(win) {
+        return function defaultFactory() {
+            const contextWindow = win && win.AudioContext ? win : (typeof window !== 'undefined' ? window : undefined);
+            const AudioContextConstructor = contextWindow ? (contextWindow.AudioContext || contextWindow.webkitAudioContext) : undefined;
+            if (!AudioContextConstructor) {
+                return null;
+            }
+            try {
+                return new AudioContextConstructor();
+            } catch (error) {
+                return null;
+            }
+        };
+    }
+
+    function isDomElement(value) {
+        if (!value || typeof value !== 'object') {
+            return false;
+        }
+        return typeof Element === 'undefined' || value instanceof Element;
+    }
+
+    class VisualizerSettings {
+        constructor(options = {}) {
+            this.storage = options.storage && typeof options.storage.getItem === 'function' ? options.storage : null;
+            this.storageKey = typeof options.storageKey === 'string' && options.storageKey.trim() !== ''
+                ? options.storageKey
+                : 'myplayer.visualizer';
+            this.availableModes = Array.isArray(options.modes) && options.modes.length ? options.modes.slice() : SUPPORTED_MODES.slice();
+            this.availableThemes = Array.isArray(options.themes) && options.themes.length ? options.themes.slice() : Object.keys(THEMES);
+            const defaults = options.defaults && typeof options.defaults === 'object' ? options.defaults : {};
+            this.defaults = Object.assign({}, DEFAULT_SETTINGS, defaults);
+            this.cache = null;
+        }
+
+        normalize(settings) {
+            const normalized = Object.assign({}, this.defaults);
+
+            normalized.enabled = Boolean(settings.enabled);
+
+            const requestedMode = typeof settings.mode === 'string' ? settings.mode : this.defaults.mode;
+            normalized.mode = this.availableModes.includes(requestedMode) ? requestedMode : this.defaults.mode;
+
+            const requestedSensitivity = Number.parseFloat(settings.sensitivity);
+            normalized.sensitivity = clamp(Number.isFinite(requestedSensitivity) ? requestedSensitivity : this.defaults.sensitivity, 0.1, 2);
+
+            const requestedSmoothing = Number.parseFloat(settings.smoothing);
+            normalized.smoothing = clamp(Number.isFinite(requestedSmoothing) ? requestedSmoothing : this.defaults.smoothing, 0, 0.99);
+
+            const requestedTheme = typeof settings.theme === 'string' ? settings.theme : this.defaults.theme;
+            normalized.theme = this.availableThemes.includes(requestedTheme) ? requestedTheme : this.defaults.theme;
+
+            return normalized;
+        }
+
+        load() {
+            if (this.cache) {
+                return Object.assign({}, this.cache);
+            }
+
+            let payload = {};
+            if (this.storage) {
+                try {
+                    const raw = this.storage.getItem(this.storageKey);
+                    if (typeof raw === 'string' && raw.trim() !== '') {
+                        payload = JSON.parse(raw);
+                    }
+                } catch (error) {
+                    payload = {};
+                }
+            }
+
+            this.cache = this.normalize(Object.assign({}, this.defaults, payload));
+
+            return Object.assign({}, this.cache);
+        }
+
+        save(settings) {
+            this.cache = this.normalize(settings || {});
+            if (this.storage) {
+                try {
+                    this.storage.setItem(this.storageKey, JSON.stringify(this.cache));
+                } catch (error) {
+                    // ignore storage write failures
+                }
+            }
+
+            return Object.assign({}, this.cache);
+        }
+
+        update(partial) {
+            const current = this.load();
+            const merged = Object.assign({}, current, partial || {});
+
+            return this.save(merged);
+        }
+    }
+
+    class VisualizerEngine {
+        constructor(audioElement, canvasElement, options = {}) {
+            this.audio = audioElement;
+            this.canvas = canvasElement;
+            this.ctx = this.canvas && typeof this.canvas.getContext === 'function' ? this.canvas.getContext('2d') : null;
+            const initial = Object.assign({}, DEFAULT_SETTINGS, options.initialSettings || {});
+            this.settings = this.validateSettings(initial);
+            this.theme = THEMES[this.settings.theme] || THEMES.neon;
+            this.requestAnimationFrame = typeof options.requestAnimationFrame === 'function'
+                ? options.requestAnimationFrame
+                : (defaultWindow && defaultWindow.requestAnimationFrame ? defaultWindow.requestAnimationFrame.bind(defaultWindow) : fallbackRequestAnimationFrame);
+            this.cancelAnimationFrame = typeof options.cancelAnimationFrame === 'function'
+                ? options.cancelAnimationFrame
+                : (defaultWindow && defaultWindow.cancelAnimationFrame ? defaultWindow.cancelAnimationFrame.bind(defaultWindow) : fallbackCancelAnimationFrame);
+            this.audioContextFactory = typeof options.audioContextFactory === 'function'
+                ? options.audioContextFactory
+                : createDefaultAudioContextFactory(defaultWindow);
+            this.onStateChange = typeof options.onStateChange === 'function' ? options.onStateChange : null;
+
+            this.frameId = null;
+            this.isRendering = false;
+            this.pageVisible = true;
+            this.pixelRatio = 1;
+            this.viewportWidth = 0;
+            this.viewportHeight = 0;
+
+            this.audioContext = null;
+            this.analyser = null;
+            this.sourceNode = null;
+            this.audioGraphConnected = false;
+            this.frequencyData = null;
+            this.timeDomainData = null;
+            this.particles = [];
+
+            this.gradientCache = { height: 0, gradient: null };
+
+            this.renderStep = this.renderStep.bind(this);
+            this.notifyState(this.settings.enabled ? 'idle' : 'disabled');
+        }
+
+        validateSettings(settings) {
+            return {
+                enabled: Boolean(settings.enabled),
+                mode: SUPPORTED_MODES.includes(settings.mode) ? settings.mode : DEFAULT_SETTINGS.mode,
+                sensitivity: clamp(Number.parseFloat(settings.sensitivity), 0.1, 2) || DEFAULT_SETTINGS.sensitivity,
+                smoothing: clamp(Number.parseFloat(settings.smoothing), 0, 0.99) || DEFAULT_SETTINGS.smoothing,
+                theme: typeof settings.theme === 'string' && THEMES[settings.theme] ? settings.theme : DEFAULT_SETTINGS.theme,
+            };
+        }
+
+        notifyState(state) {
+            this.currentState = state;
+            if (this.onStateChange) {
+                try {
+                    this.onStateChange(state);
+                } catch (error) {
+                    // suppress listener errors
+                }
+            }
+        }
+
+        setDimensions(width, height, pixelRatio = 1) {
+            this.viewportWidth = width;
+            this.viewportHeight = height;
+            this.pixelRatio = pixelRatio;
+            if (this.ctx && typeof this.ctx.setTransform === 'function') {
+                this.ctx.setTransform(this.pixelRatio, 0, 0, this.pixelRatio, 0, 0);
+            }
+            this.gradientCache = { height: 0, gradient: null };
+        }
+
+        getWidth() {
+            return this.viewportWidth || (this.canvas ? this.canvas.width / this.pixelRatio : 0);
+        }
+
+        getHeight() {
+            return this.viewportHeight || (this.canvas ? this.canvas.height / this.pixelRatio : 0);
+        }
+
+        setPageVisibility(isVisible) {
+            this.pageVisible = Boolean(isVisible);
+            if (!this.pageVisible) {
+                this.stopRendering();
+                if (this.settings.enabled) {
+                    this.notifyState('idle');
+                }
+                return;
+            }
+            if (this.settings.enabled && this.audio && !this.audio.paused) {
+                this.handlePlay();
+            }
+        }
+
+        setEnabled(enabled) {
+            const value = Boolean(enabled);
+            if (this.settings.enabled === value) {
+                if (!value) {
+                    this.notifyState('disabled');
+                }
+                return this.settings.enabled;
+            }
+
+            this.settings.enabled = value;
+            if (!value) {
+                this.stopRendering();
+                this.notifyState('disabled');
+                return this.settings.enabled;
+            }
+
+            this.notifyState('idle');
+            if (this.audio && !this.audio.paused && this.pageVisible) {
+                this.handlePlay();
+            }
+
+            return this.settings.enabled;
+        }
+
+        setMode(mode) {
+            if (!SUPPORTED_MODES.includes(mode)) {
+                return this.settings.mode;
+            }
+            this.settings.mode = mode;
+            return this.settings.mode;
+        }
+
+        setSensitivity(value) {
+            const normalized = clamp(Number.parseFloat(value), 0.1, 2) || this.settings.sensitivity;
+            this.settings.sensitivity = normalized;
+            return this.settings.sensitivity;
+        }
+
+        setSmoothing(value) {
+            const normalized = clamp(Number.parseFloat(value), 0, 0.99) || this.settings.smoothing;
+            this.settings.smoothing = normalized;
+            if (this.analyser) {
+                this.analyser.smoothingTimeConstant = this.settings.smoothing;
+            }
+            return this.settings.smoothing;
+        }
+
+        setTheme(theme) {
+            if (typeof theme !== 'string' || !THEMES[theme]) {
+                return this.settings.theme;
+            }
+            this.settings.theme = theme;
+            this.theme = THEMES[theme];
+            this.gradientCache = { height: 0, gradient: null };
+            return this.settings.theme;
+        }
+
+        applySettings(settings) {
+            if (!settings) {
+                return;
+            }
+            this.setTheme(settings.theme);
+            this.setMode(settings.mode);
+            this.setSensitivity(settings.sensitivity);
+            this.setSmoothing(settings.smoothing);
+            this.setEnabled(settings.enabled);
+        }
+
+        ensureAnalyser() {
+            if (!this.ctx || !this.canvas || !this.audio) {
+                return false;
+            }
+
+            if (!this.audioContext) {
+                this.audioContext = this.audioContextFactory ? this.audioContextFactory() : null;
+            }
+
+            if (!this.audioContext) {
+                return false;
+            }
+
+            if (typeof this.audioContext.resume === 'function' && this.audioContext.state === 'suspended') {
+                try {
+                    this.audioContext.resume();
+                } catch (error) {
+                    // ignore resume errors
+                }
+            }
+
+            if (!this.analyser) {
+                if (typeof this.audioContext.createAnalyser !== 'function' || typeof this.audioContext.createMediaElementSource !== 'function') {
+                    return false;
+                }
+                this.analyser = this.audioContext.createAnalyser();
+                this.analyser.fftSize = 2048;
+                this.analyser.smoothingTimeConstant = this.settings.smoothing;
+                this.frequencyData = new Uint8Array(this.analyser.frequencyBinCount);
+                this.timeDomainData = new Uint8Array(this.analyser.fftSize);
+                if (!this.sourceNode) {
+                    try {
+                        this.sourceNode = this.audioContext.createMediaElementSource(this.audio);
+                    } catch (error) {
+                        if (!this.sourceNode) {
+                            return false;
+                        }
+                    }
+                }
+                if (!this.audioGraphConnected && this.sourceNode) {
+                    if (typeof this.sourceNode.connect === 'function') {
+                        this.sourceNode.connect(this.analyser);
+                        if (this.audioContext.destination) {
+                            this.analyser.connect(this.audioContext.destination);
+                        }
+                    }
+                    this.audioGraphConnected = true;
+                }
+            }
+
+            if (!this.frequencyData || this.frequencyData.length !== this.analyser.frequencyBinCount) {
+                this.frequencyData = new Uint8Array(this.analyser.frequencyBinCount);
+            }
+            if (!this.timeDomainData || this.timeDomainData.length !== this.analyser.fftSize) {
+                this.timeDomainData = new Uint8Array(this.analyser.fftSize);
+            }
+
+            this.analyser.smoothingTimeConstant = this.settings.smoothing;
+
+            return true;
+        }
+
+        handlePlay() {
+            if (!this.settings.enabled || !this.pageVisible) {
+                return;
+            }
+            if (!this.ensureAnalyser()) {
+                return;
+            }
+            this.notifyState('running');
+            this.startRendering();
+        }
+
+        handlePause() {
+            this.stopRendering();
+            this.notifyState(this.settings.enabled ? 'idle' : 'disabled');
+        }
+
+        startRendering() {
+            if (this.isRendering) {
+                return;
+            }
+            this.isRendering = true;
+            this.frameId = this.requestAnimationFrame(this.renderStep);
+        }
+
+        renderStep() {
+            if (!this.isRendering) {
+                return;
+            }
+            this.renderFrame();
+            this.frameId = this.requestAnimationFrame(this.renderStep);
+        }
+
+        stopRendering() {
+            if (!this.isRendering) {
+                return;
+            }
+            this.isRendering = false;
+            if (this.frameId !== null) {
+                this.cancelAnimationFrame(this.frameId);
+                this.frameId = null;
+            }
+        }
+
+        renderFrame() {
+            if (!this.analyser || !this.ctx) {
+                return;
+            }
+            switch (this.settings.mode) {
+                case 'wave':
+                    this.renderWave();
+                    break;
+                case 'rings':
+                    this.renderRings();
+                    break;
+                case 'particles':
+                    this.renderParticles();
+                    break;
+                case 'bars':
+                default:
+                    this.renderBars();
+                    break;
+            }
+        }
+
+        prepareBackground(alphaFactor) {
+            const width = this.getWidth();
+            const height = this.getHeight();
+            if (width === 0 || height === 0) {
+                return;
+            }
+            const ctx = this.ctx;
+            ctx.save();
+            ctx.globalCompositeOperation = 'source-over';
+            const base = this.theme.background;
+            if (typeof alphaFactor === 'number' && base.startsWith('rgba')) {
+                const segments = base.slice(5, -1).split(',').map((item) => item.trim());
+                if (segments.length === 4) {
+                    segments[3] = String(alphaFactor);
+                    ctx.fillStyle = `rgba(${segments.join(', ')})`;
+                } else {
+                    ctx.fillStyle = base;
+                }
+            } else {
+                ctx.fillStyle = base;
+            }
+            ctx.fillRect(0, 0, width, height);
+            ctx.restore();
+        }
+
+        obtainGradient(height) {
+            if (!this.ctx) {
+                return this.theme.gradient[0];
+            }
+            if (!this.gradientCache.gradient || this.gradientCache.height !== height) {
+                const gradient = this.ctx.createLinearGradient(0, height, 0, 0);
+                gradient.addColorStop(0, this.theme.gradient[0]);
+                gradient.addColorStop(1, this.theme.gradient[1]);
+                this.gradientCache = { height, gradient };
+            }
+            return this.gradientCache.gradient;
+        }
+
+        renderBars() {
+            this.analyser.getByteFrequencyData(this.frequencyData);
+            const width = this.getWidth();
+            const height = this.getHeight();
+            if (width === 0 || height === 0) {
+                return;
+            }
+            this.prepareBackground();
+            const ctx = this.ctx;
+            const barCount = 64;
+            const slice = Math.max(1, Math.floor(this.frequencyData.length / barCount));
+            const barWidth = width / barCount;
+            ctx.save();
+            ctx.fillStyle = this.obtainGradient(height);
+            ctx.shadowBlur = 18;
+            ctx.shadowColor = this.theme.glow;
+            for (let index = 0; index < barCount; index += 1) {
+                const sampleIndex = index * slice;
+                const sample = this.frequencyData[Math.min(sampleIndex, this.frequencyData.length - 1)] / 255;
+                const magnitude = Math.pow(sample, 1.35) * height * 0.9 * this.settings.sensitivity;
+                const barHeight = Math.max(4, magnitude);
+                const x = index * barWidth;
+                const y = height - barHeight;
+                ctx.beginPath();
+                const radius = Math.min(barWidth / 2.5, 12);
+                const adjustedWidth = barWidth * 0.65;
+                const offsetX = x + (barWidth - adjustedWidth) / 2;
+                ctx.moveTo(offsetX, height);
+                ctx.lineTo(offsetX, y + radius);
+                ctx.quadraticCurveTo(offsetX, y, offsetX + radius, y);
+                ctx.lineTo(offsetX + adjustedWidth - radius, y);
+                ctx.quadraticCurveTo(offsetX + adjustedWidth, y, offsetX + adjustedWidth, y + radius);
+                ctx.lineTo(offsetX + adjustedWidth, height);
+                ctx.closePath();
+                ctx.fill();
+            }
+            ctx.restore();
+        }
+
+        renderWave() {
+            this.analyser.getByteTimeDomainData(this.timeDomainData);
+            const width = this.getWidth();
+            const height = this.getHeight();
+            if (width === 0 || height === 0) {
+                return;
+            }
+            this.prepareBackground(0.85);
+            const ctx = this.ctx;
+            ctx.save();
+            ctx.lineWidth = Math.max(1.5, this.settings.sensitivity * 2.2);
+            ctx.lineJoin = 'round';
+            ctx.lineCap = 'round';
+            ctx.shadowBlur = 14;
+            ctx.shadowColor = this.theme.glow;
+            ctx.strokeStyle = this.theme.gradient[0];
+            ctx.beginPath();
+            const slice = width / this.timeDomainData.length;
+            let x = 0;
+            for (let i = 0; i < this.timeDomainData.length; i += 1) {
+                const value = (this.timeDomainData[i] / 255) * 2 - 1;
+                const amplitude = value * (height / 2) * this.settings.sensitivity;
+                const y = height / 2 + amplitude;
+                if (i === 0) {
+                    ctx.moveTo(x, y);
+                } else {
+                    ctx.lineTo(x, y);
+                }
+                x += slice;
+            }
+            ctx.stroke();
+            ctx.restore();
+        }
+
+        renderRings() {
+            this.analyser.getByteFrequencyData(this.frequencyData);
+            const width = this.getWidth();
+            const height = this.getHeight();
+            if (width === 0 || height === 0) {
+                return;
+            }
+            this.prepareBackground(0.75);
+            const ctx = this.ctx;
+            const centerX = width / 2;
+            const centerY = height / 2;
+            const ringCount = 3;
+            const maxRadius = Math.min(width, height) / 2.4;
+            ctx.save();
+            ctx.lineWidth = 2.2;
+            ctx.shadowBlur = 16;
+            ctx.shadowColor = this.theme.glow;
+            for (let ring = 0; ring < ringCount; ring += 1) {
+                const baseRadius = (maxRadius / ringCount) * (ring + 1);
+                const offset = ring * 32;
+                ctx.beginPath();
+                const steps = 120;
+                for (let step = 0; step <= steps; step += 1) {
+                    const index = Math.min(offset + step, this.frequencyData.length - 1);
+                    const sample = this.frequencyData[index] / 255;
+                    const dynamicRadius = baseRadius + sample * maxRadius * 0.3 * this.settings.sensitivity;
+                    const angle = (step / steps) * Math.PI * 2;
+                    const x = centerX + Math.cos(angle) * dynamicRadius;
+                    const y = centerY + Math.sin(angle) * dynamicRadius;
+                    if (step === 0) {
+                        ctx.moveTo(x, y);
+                    } else {
+                        ctx.lineTo(x, y);
+                    }
+                }
+                ctx.closePath();
+                const gradient = ctx.createRadialGradient(centerX, centerY, baseRadius * 0.2, centerX, centerY, baseRadius);
+                gradient.addColorStop(0, this.theme.gradient[1]);
+                gradient.addColorStop(1, this.theme.gradient[0]);
+                ctx.strokeStyle = gradient;
+                ctx.stroke();
+            }
+            ctx.restore();
+        }
+
+        initParticles(count) {
+            this.particles = [];
+            for (let index = 0; index < count; index += 1) {
+                this.particles.push({
+                    angle: (Math.PI * 2 * index) / count,
+                    speed: 0.004 + Math.random() * 0.003,
+                    baseRadius: 0.35 + Math.random() * 0.65,
+                    size: 2 + Math.random() * 3,
+                });
+            }
+        }
+
+        getAverageFrequency() {
+            if (!this.frequencyData || !this.frequencyData.length) {
+                return 0;
+            }
+            let sum = 0;
+            for (let i = 0; i < this.frequencyData.length; i += 1) {
+                sum += this.frequencyData[i];
+            }
+            return sum / this.frequencyData.length / 255;
+        }
+
+        renderParticles() {
+            this.analyser.getByteFrequencyData(this.frequencyData);
+            const width = this.getWidth();
+            const height = this.getHeight();
+            if (width === 0 || height === 0) {
+                return;
+            }
+            if (!this.particles.length) {
+                this.initParticles(90);
+            }
+            this.prepareBackground(0.2);
+            const ctx = this.ctx;
+            const centerX = width / 2;
+            const centerY = height / 2;
+            const radiusBase = Math.min(width, height) / 4;
+            const average = this.getAverageFrequency();
+            ctx.save();
+            ctx.globalCompositeOperation = 'lighter';
+            ctx.shadowBlur = 18;
+            ctx.shadowColor = this.theme.glow;
+            for (let index = 0; index < this.particles.length; index += 1) {
+                const particle = this.particles[index];
+                const freqIndex = Math.floor((index / this.particles.length) * this.frequencyData.length);
+                const sample = this.frequencyData[Math.min(freqIndex, this.frequencyData.length - 1)] / 255;
+                particle.angle += particle.speed * (0.5 + average * 1.5);
+                const dynamicRadius = radiusBase * particle.baseRadius + sample * radiusBase * this.settings.sensitivity * 1.2;
+                const x = centerX + Math.cos(particle.angle) * dynamicRadius;
+                const y = centerY + Math.sin(particle.angle) * dynamicRadius;
+                const size = particle.size * (0.4 + sample * 1.4);
+                ctx.beginPath();
+                ctx.globalAlpha = 0.45 + sample * 0.55;
+                ctx.fillStyle = this.theme.particle;
+                ctx.arc(x, y, size, 0, Math.PI * 2);
+                ctx.fill();
+            }
+            ctx.restore();
+            ctx.globalAlpha = 1;
+            ctx.globalCompositeOperation = 'source-over';
+        }
+    }
+
+    function attachVisualizer(options = {}) {
+        const root = options.root;
+        const audio = options.audio;
+        if (!root || !audio) {
+            return null;
+        }
+
+        const canvas = root.querySelector('#visualizer');
+        if (!canvas || typeof canvas.getContext !== 'function') {
+            return null;
+        }
+
+        const windowRef = options.window || defaultWindow;
+        const documentRef = options.document || (windowRef ? windowRef.document : undefined);
+        const storage = options.storage && typeof options.storage.getItem === 'function'
+            ? options.storage
+            : (windowRef && windowRef.localStorage ? windowRef.localStorage : null);
+
+        let defaults = {};
+        const defaultsAttr = root.getAttribute('data-visualizer-defaults');
+        if (defaultsAttr) {
+            try {
+                const parsed = JSON.parse(defaultsAttr);
+                if (parsed && typeof parsed === 'object') {
+                    defaults = parsed;
+                }
+            } catch (error) {
+                defaults = {};
+            }
+        }
+
+        const settingsManager = new VisualizerSettings({
+            storage,
+            storageKey: options.storageKey || 'myplayer.visualizer',
+            defaults,
+            modes: SUPPORTED_MODES,
+            themes: Object.keys(THEMES),
+        });
+
+        let settings = settingsManager.load();
+
+        const toggle = root.querySelector('[data-visualizer-toggle]');
+        const modeButtons = Array.from(root.querySelectorAll('[data-visualizer-mode]'));
+        const sensitivityInput = root.querySelector('[data-visualizer-sensitivity]');
+        const smoothingInput = root.querySelector('[data-visualizer-smoothing]');
+        const themeSelect = root.querySelector('[data-visualizer-theme]');
+        const placeholder = root.querySelector('[data-visualizer-placeholder]');
+        const placeholderMessage = placeholder ? placeholder.querySelector('p') : null;
+        const stateBadge = root.querySelector('[data-visualizer-state]');
+        const sensitivityValue = root.querySelector('[data-visualizer-sensitivity-value]');
+        const smoothingValue = root.querySelector('[data-visualizer-smoothing-value]');
+        const canvasWrapper = root.querySelector('.visualizer-canvas');
+
+        const engine = new VisualizerEngine(audio, canvas, {
+            initialSettings: settings,
+            requestAnimationFrame: options.requestAnimationFrame,
+            cancelAnimationFrame: options.cancelAnimationFrame,
+            audioContextFactory: options.audioContextFactory || createDefaultAudioContextFactory(windowRef),
+            onStateChange: updateState,
+        });
+
+        settings = settingsManager.save(engine.settings);
+
+        function updateTheme(theme) {
+            if (typeof theme !== 'string') {
+                return;
+            }
+            root.setAttribute('data-visualizer-theme', theme);
+        }
+
+        function updateModeButtons(mode) {
+            modeButtons.forEach((button) => {
+                if (!isDomElement(button)) {
+                    return;
+                }
+                const value = button.getAttribute('data-visualizer-mode');
+                button.classList.toggle('active', value === mode);
+            });
+        }
+
+        function updateSensitivityLabel(value) {
+            if (!sensitivityValue) {
+                return;
+            }
+            const numeric = Number.parseFloat(value);
+            const display = Number.isFinite(numeric) ? numeric.toFixed(2) : '0.00';
+            sensitivityValue.textContent = `×${display}`;
+        }
+
+        function updateSmoothingLabel(value) {
+            if (!smoothingValue) {
+                return;
+            }
+            const numeric = Number.parseFloat(value);
+            const display = Number.isFinite(numeric) ? Math.round(numeric * 100) : 0;
+            smoothingValue.textContent = `${display}%`;
+        }
+
+        function updateState(state) {
+            if (isDomElement(stateBadge)) {
+                stateBadge.setAttribute('data-state', state);
+                if (state === 'running') {
+                    stateBadge.textContent = 'Воспроизведение';
+                } else if (state === 'disabled') {
+                    stateBadge.textContent = 'Выключено';
+                } else {
+                    stateBadge.textContent = 'Готово';
+                }
+            }
+            if (isDomElement(placeholder)) {
+                if (state === 'running') {
+                    placeholder.setAttribute('data-state', 'hidden');
+                } else {
+                    placeholder.setAttribute('data-state', 'visible');
+                    if (placeholderMessage) {
+                        if (state === 'disabled') {
+                            placeholderMessage.textContent = 'Визуализация выключена';
+                        } else if (documentRef && documentRef.hidden) {
+                            placeholderMessage.textContent = 'Вкладка свернута — визуализация на паузе';
+                        } else if (audio.paused) {
+                            placeholderMessage.textContent = 'Воспроизведите трек, чтобы увидеть визуализацию';
+                        } else {
+                            placeholderMessage.textContent = 'Ожидание аудиосигнала';
+                        }
+                    }
+                }
+            }
+        }
+
+        function syncUI() {
+            if (toggle && typeof toggle === 'object' && 'checked' in toggle) {
+                toggle.checked = Boolean(settings.enabled);
+            }
+            if (sensitivityInput && typeof sensitivityInput === 'object' && 'value' in sensitivityInput) {
+                sensitivityInput.value = String(settings.sensitivity);
+            }
+            if (smoothingInput && typeof smoothingInput === 'object' && 'value' in smoothingInput) {
+                smoothingInput.value = String(settings.smoothing);
+            }
+            if (themeSelect && typeof themeSelect === 'object' && 'value' in themeSelect) {
+                themeSelect.value = settings.theme;
+            }
+            updateModeButtons(settings.mode);
+            updateSensitivityLabel(settings.sensitivity);
+            updateSmoothingLabel(settings.smoothing);
+            updateTheme(settings.theme);
+        }
+
+        function updateCanvasSize() {
+            if (!canvasWrapper || !canvas) {
+                return;
+            }
+            const rect = typeof canvasWrapper.getBoundingClientRect === 'function'
+                ? canvasWrapper.getBoundingClientRect()
+                : { width: canvasWrapper.clientWidth, height: canvasWrapper.clientHeight };
+            if (!rect || rect.width === 0 || rect.height === 0) {
+                return;
+            }
+            const ratio = windowRef && windowRef.devicePixelRatio ? windowRef.devicePixelRatio : 1;
+            canvas.width = rect.width * ratio;
+            canvas.height = rect.height * ratio;
+            canvas.style.width = `${rect.width}px`;
+            canvas.style.height = `${rect.height}px`;
+            engine.setDimensions(rect.width, rect.height, ratio);
+        }
+
+        const cleanup = [];
+
+        if (toggle && typeof toggle.addEventListener === 'function') {
+            const handler = () => {
+                settings = settingsManager.update({ enabled: Boolean(toggle.checked) });
+                engine.setEnabled(settings.enabled);
+                syncUI();
+            };
+            toggle.addEventListener('change', handler);
+            cleanup.push(() => toggle.removeEventListener('change', handler));
+        }
+
+        modeButtons.forEach((button) => {
+            if (!isDomElement(button) || typeof button.addEventListener !== 'function') {
+                return;
+            }
+            const mode = button.getAttribute('data-visualizer-mode');
+            if (!mode) {
+                return;
+            }
+            const handler = () => {
+                settings = settingsManager.update({ mode });
+                engine.setMode(settings.mode);
+                updateModeButtons(settings.mode);
+            };
+            button.addEventListener('click', handler);
+            cleanup.push(() => button.removeEventListener('click', handler));
+        });
+
+        if (sensitivityInput && typeof sensitivityInput.addEventListener === 'function') {
+            const handler = () => {
+                const value = Number.parseFloat(sensitivityInput.value);
+                settings = settingsManager.update({ sensitivity: value });
+                engine.setSensitivity(settings.sensitivity);
+                updateSensitivityLabel(settings.sensitivity);
+            };
+            sensitivityInput.addEventListener('input', handler);
+            cleanup.push(() => sensitivityInput.removeEventListener('input', handler));
+        }
+
+        if (smoothingInput && typeof smoothingInput.addEventListener === 'function') {
+            const handler = () => {
+                const value = Number.parseFloat(smoothingInput.value);
+                settings = settingsManager.update({ smoothing: value });
+                engine.setSmoothing(settings.smoothing);
+                updateSmoothingLabel(settings.smoothing);
+            };
+            smoothingInput.addEventListener('input', handler);
+            cleanup.push(() => smoothingInput.removeEventListener('input', handler));
+        }
+
+        if (themeSelect && typeof themeSelect.addEventListener === 'function') {
+            const handler = () => {
+                const theme = themeSelect.value;
+                settings = settingsManager.update({ theme });
+                engine.setTheme(settings.theme);
+                updateTheme(settings.theme);
+            };
+            themeSelect.addEventListener('change', handler);
+            cleanup.push(() => themeSelect.removeEventListener('change', handler));
+        }
+
+        const onPlay = () => engine.handlePlay();
+        const onPause = () => engine.handlePause();
+        const onEnded = () => engine.handlePause();
+        if (typeof audio.addEventListener === 'function') {
+            audio.addEventListener('play', onPlay);
+            audio.addEventListener('pause', onPause);
+            audio.addEventListener('ended', onEnded);
+            cleanup.push(() => {
+                audio.removeEventListener('play', onPlay);
+                audio.removeEventListener('pause', onPause);
+                audio.removeEventListener('ended', onEnded);
+            });
+        }
+
+        const onVisibilityChange = () => {
+            const visible = !(documentRef && documentRef.hidden);
+            engine.setPageVisibility(visible);
+        };
+        if (documentRef && typeof documentRef.addEventListener === 'function') {
+            documentRef.addEventListener('visibilitychange', onVisibilityChange);
+            cleanup.push(() => documentRef.removeEventListener('visibilitychange', onVisibilityChange));
+        }
+
+        updateCanvasSize();
+        let resizeObserver = null;
+        if (canvasWrapper && windowRef && typeof windowRef.ResizeObserver === 'function') {
+            resizeObserver = new windowRef.ResizeObserver(updateCanvasSize);
+            resizeObserver.observe(canvasWrapper);
+            cleanup.push(() => resizeObserver && resizeObserver.disconnect());
+        } else if (windowRef && typeof windowRef.addEventListener === 'function') {
+            windowRef.addEventListener('resize', updateCanvasSize);
+            cleanup.push(() => windowRef.removeEventListener('resize', updateCanvasSize));
+        }
+
+        engine.setPageVisibility(!(documentRef && documentRef.hidden));
+        engine.applySettings(settings);
+        settings = settingsManager.save(engine.settings);
+        syncUI();
+        updateState(engine.currentState || (settings.enabled ? 'idle' : 'disabled'));
+
+        return {
+            engine,
+            getSettings: () => Object.assign({}, settings),
+            destroy() {
+                cleanup.forEach((fn) => {
+                    try {
+                        fn();
+                    } catch (error) {
+                        // ignore teardown errors
+                    }
+                });
+            },
+        };
+    }
+
+    const api = {
+        VisualizerSettings,
+        VisualizerEngine,
+        attachVisualizer,
+        SUPPORTED_MODES,
+        THEMES,
+        DEFAULT_SETTINGS,
+    };
+
+    global.MyPlayerVisualizer = Object.assign({}, global.MyPlayerVisualizer || {}, api);
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -16,6 +16,15 @@ class DefaultController extends AbstractController
     {
         $tracks = $trackRepository->findBy([], ['id' => 'DESC']);
 
+        $featureFlags = [
+            'visualizer' => (bool) $this->getParameter('features.visualizer'),
+        ];
+
+        $visualizerDefaults = $this->getParameter('visualizer.defaults');
+        if (!\is_array($visualizerDefaults)) {
+            $visualizerDefaults = [];
+        }
+
         return $this->render('home/index.html.twig', [
             'tracks' => $tracks,
             'artistCounts' => $this->groupByCounts($tracks, static fn (Track $track): ?string => $track->getArtist(), TrackManager::UNKNOWN_ARTIST),
@@ -25,6 +34,8 @@ class DefaultController extends AbstractController
                 'artist' => TrackManager::UNKNOWN_ARTIST,
                 'album' => TrackManager::UNKNOWN_ALBUM,
             ],
+            'featureFlags' => $featureFlags,
+            'visualizerDefaults' => $visualizerDefaults,
         ]);
     }
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -30,6 +30,7 @@
             </main>
         </div>
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+        <script src="{{ asset('visualizer.js') }}" defer></script>
         <script src="{{ asset('app.js') }}" defer></script>
         {% block javascripts %}{% endblock %}
     </body>

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -68,6 +68,65 @@
                             </a>
                         </div>
 
+                        {% if featureFlags.visualizer ?? false %}
+                            <div class="visualizer-panel" data-visualizer-root data-visualizer-defaults="{{ (visualizerDefaults|default({}))|json_encode|e('html_attr') }}">
+                                <div class="visualizer-toolbar d-flex flex-wrap align-items-center justify-content-between gap-3">
+                                    <div class="d-flex align-items-center gap-3">
+                                        <div class="visualizer-icon d-flex align-items-center justify-content-center rounded-circle">
+                                            <i class="bi bi-activity"></i>
+                                        </div>
+                                        <div>
+                                            <div class="fw-semibold">Визуализация</div>
+                                            <div class="text-muted small">Анимация звука в реальном времени</div>
+                                        </div>
+                                    </div>
+                                    <div class="d-flex align-items-center gap-3 flex-wrap justify-content-end">
+                                        <span class="badge rounded-pill visualizer-state" data-visualizer-state>Выключено</span>
+                                        <div class="form-check form-switch m-0">
+                                            <input class="form-check-input" type="checkbox" role="switch" id="visualizerToggle" data-visualizer-toggle>
+                                            <label class="form-check-label" for="visualizerToggle">Включить</label>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="visualizer-modes btn-group flex-wrap w-100" role="group" aria-label="Режим визуализации">
+                                    <button type="button" class="btn" data-visualizer-mode="bars">Бары</button>
+                                    <button type="button" class="btn" data-visualizer-mode="wave">Волна</button>
+                                    <button type="button" class="btn" data-visualizer-mode="rings">Кольца</button>
+                                    <button type="button" class="btn" data-visualizer-mode="particles">Частицы</button>
+                                </div>
+                                <div class="visualizer-canvas mt-3">
+                                    <canvas id="visualizer"></canvas>
+                                    <div class="visualizer-placeholder" data-visualizer-placeholder>
+                                        <div class="visualizer-placeholder-content text-center">
+                                            <i class="bi bi-soundwave mb-2"></i>
+                                            <p class="mb-0">Воспроизведите трек, чтобы увидеть визуализацию</p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row g-4 mt-1 visualizer-settings">
+                                    <div class="col-md-4">
+                                        <label for="visualizerSensitivity" class="form-label text-uppercase small fw-semibold">Чувствительность</label>
+                                        <input type="range" class="form-range" min="0.4" max="1.5" step="0.05" id="visualizerSensitivity" data-visualizer-sensitivity>
+                                        <div class="form-text text-muted" data-visualizer-sensitivity-value></div>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <label for="visualizerSmoothing" class="form-label text-uppercase small fw-semibold">Сглаживание</label>
+                                        <input type="range" class="form-range" min="0" max="0.95" step="0.05" id="visualizerSmoothing" data-visualizer-smoothing>
+                                        <div class="form-text text-muted" data-visualizer-smoothing-value></div>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <label for="visualizerTheme" class="form-label text-uppercase small fw-semibold">Цветовая тема</label>
+                                        <select class="form-select" id="visualizerTheme" data-visualizer-theme>
+                                            <option value="neon">Неон</option>
+                                            <option value="aurora">Аврора</option>
+                                            <option value="sunset">Закат</option>
+                                            <option value="light">Светлая</option>
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
+                        {% endif %}
+
                         {% if tracks is not empty %}
                             <div class="track-collection d-flex flex-column gap-2" data-track-list>
                                 {% for track in tracks %}

--- a/tests/js/visualizer.test.js
+++ b/tests/js/visualizer.test.js
@@ -1,0 +1,238 @@
+const assert = require('assert');
+const path = require('path');
+
+const visualizer = require(path.join(__dirname, '../../public/visualizer.js'));
+const {
+    VisualizerSettings,
+    VisualizerEngine,
+    SUPPORTED_MODES,
+    THEMES,
+} = visualizer;
+
+function createStorageMock() {
+    const store = new Map();
+    return {
+        getItem(key) {
+            return store.has(key) ? store.get(key) : null;
+        },
+        setItem(key, value) {
+            store.set(key, value);
+        },
+        removeItem(key) {
+            store.delete(key);
+        },
+    };
+}
+
+function createAnalyserStub() {
+    let fftSize = 2048;
+    return {
+        get fftSize() {
+            return fftSize;
+        },
+        set fftSize(value) {
+            fftSize = value;
+        },
+        get frequencyBinCount() {
+            return fftSize / 2;
+        },
+        smoothingTimeConstant: 0,
+        getByteFrequencyData(target) {
+            for (let index = 0; index < target.length; index += 1) {
+                target[index] = index % 255;
+            }
+        },
+        getByteTimeDomainData(target) {
+            for (let index = 0; index < target.length; index += 1) {
+                target[index] = 128;
+            }
+        },
+        connect() {},
+    };
+}
+
+function createAudioContextStub() {
+    let analyser = createAnalyserStub();
+    return {
+        state: 'running',
+        resume() {
+            this.state = 'running';
+        },
+        createAnalyser() {
+            analyser = createAnalyserStub();
+            return analyser;
+        },
+        createMediaElementSource() {
+            return {
+                connect() {},
+            };
+        },
+        get destination() {
+            return {};
+        },
+    };
+}
+
+function createCanvasStub() {
+    const gradientStub = {
+        addColorStop() {},
+    };
+    const ctx = {
+        fillStyle: '',
+        strokeStyle: '',
+        lineWidth: 1,
+        shadowBlur: 0,
+        shadowColor: '',
+        globalAlpha: 1,
+        globalCompositeOperation: 'source-over',
+        beginPath() {},
+        moveTo() {},
+        lineTo() {},
+        stroke() {},
+        fillRect() {},
+        fill() {},
+        closePath() {},
+        quadraticCurveTo() {},
+        arc() {},
+        save() {},
+        restore() {},
+        setTransform() {},
+        createLinearGradient() {
+            return gradientStub;
+        },
+        createRadialGradient() {
+            return gradientStub;
+        },
+    };
+    return {
+        width: 0,
+        height: 0,
+        style: {},
+        getContext(type) {
+            return type === '2d' ? ctx : null;
+        },
+    };
+}
+
+function createAudioStub() {
+    return {
+        paused: true,
+        addEventListener() {},
+        removeEventListener() {},
+    };
+}
+
+const tests = [];
+function test(name, fn) {
+    tests.push({ name, fn });
+}
+
+test('settings persist between instances', () => {
+    const storage = createStorageMock();
+    const defaults = {
+        enabled: false,
+        mode: 'bars',
+        sensitivity: 0.75,
+        smoothing: 0.5,
+        theme: 'neon',
+    };
+    const manager = new VisualizerSettings({
+        storage,
+        storageKey: 'visualizer-test',
+        defaults,
+        modes: SUPPORTED_MODES,
+        themes: Object.keys(THEMES),
+    });
+    let loaded = manager.load();
+    assert.strictEqual(loaded.enabled, false);
+    manager.update({
+        enabled: true,
+        mode: 'rings',
+        sensitivity: 1.15,
+        smoothing: 0.9,
+        theme: 'sunset',
+    });
+    loaded = manager.load();
+    assert.strictEqual(loaded.mode, 'rings');
+    assert.ok(Math.abs(loaded.sensitivity - 1.15) < 1e-6);
+    const secondManager = new VisualizerSettings({
+        storage,
+        storageKey: 'visualizer-test',
+        defaults,
+        modes: SUPPORTED_MODES,
+        themes: Object.keys(THEMES),
+    });
+    const persisted = secondManager.load();
+    assert.strictEqual(persisted.theme, 'sunset');
+    assert.strictEqual(persisted.enabled, true);
+});
+
+test('mode switching updates the engine state', () => {
+    const audio = createAudioStub();
+    const canvas = createCanvasStub();
+    const engine = new VisualizerEngine(audio, canvas, {
+        initialSettings: {
+            enabled: false,
+            mode: 'bars',
+            sensitivity: 0.9,
+            smoothing: 0.6,
+            theme: 'neon',
+        },
+        audioContextFactory: () => createAudioContextStub(),
+        requestAnimationFrame: () => 1,
+        cancelAnimationFrame: () => {},
+    });
+    engine.setMode('wave');
+    assert.strictEqual(engine.settings.mode, 'wave');
+    engine.setMode('invalid');
+    assert.strictEqual(engine.settings.mode, 'wave');
+});
+
+test('engine starts on play and stops on pause', () => {
+    const audio = createAudioStub();
+    const canvas = createCanvasStub();
+    const context = createAudioContextStub();
+    let rafCalls = 0;
+    let cancelCalls = 0;
+    const engine = new VisualizerEngine(audio, canvas, {
+        initialSettings: {
+            enabled: true,
+            mode: 'bars',
+            sensitivity: 1,
+            smoothing: 0.5,
+            theme: 'neon',
+        },
+        requestAnimationFrame: () => {
+            rafCalls += 1;
+            return 1;
+        },
+        cancelAnimationFrame: () => {
+            cancelCalls += 1;
+        },
+        audioContextFactory: () => context,
+    });
+    engine.setPageVisibility(true);
+    audio.paused = false;
+    engine.handlePlay();
+    assert.ok(rafCalls > 0, 'requestAnimationFrame should be called when playing');
+    engine.handlePause();
+    assert.ok(cancelCalls > 0, 'cancelAnimationFrame should be called when paused');
+});
+
+let failures = 0;
+for (const { name, fn } of tests) {
+    try {
+        fn();
+        console.log(`✔ ${name}`);
+    } catch (error) {
+        failures += 1;
+        console.error(`✖ ${name}`);
+        console.error(error);
+    }
+}
+
+if (failures > 0) {
+    process.exitCode = 1;
+} else {
+    console.log('All visualizer tests passed');
+}


### PR DESCRIPTION
## Summary
- add a feature flag and default configuration for the player visualizer
- extend the home template with a canvas-based visualizer panel, controls, and script loading
- implement a Web Audio API visualizer module with multiple presets, theming, and saved settings, alongside responsive styling
- include node-based tests covering settings persistence, mode changes, and playback start/stop handling

## Testing
- `node tests/js/visualizer.test.js`
- `php bin/phpunit` *(fails: simple-phpunit not installed / composer install blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cb138c5b1c832397aa97e4f1c70f3d